### PR TITLE
rubocop - turn off string literals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,8 +18,11 @@ AllCops:
 Metrics/LineLength:
   Max: 150 # would like to reduce this to 120
 
-
 Style/FileName:
   Exclude:
     - 'Gemfile'
     - 'moab-versioning.gemspec'
+
+# because it's expensive to care
+Style/StringLiterals:
+  Enabled: false

--- a/spec/spec_config.rb
+++ b/spec/spec_config.rb
@@ -1,5 +1,7 @@
 Moab::Config.configure do
-  storage_roots [File.join(File.dirname(__FILE__),"fixtures/derivatives"),File.join(File.dirname(__FILE__),"fixtures/newnode")]
+  root_path1 = File.join(File.dirname(__FILE__), "fixtures/derivatives")
+  root_path2 = File.join(File.dirname(__FILE__), "fixtures/newnode")
+  storage_roots [root_path1, root_path2]
   storage_trunk 'ingests'
   deposit_trunk 'packages'
   path_method :druid


### PR DESCRIPTION
also make spec_config more readable