### PR TITLE
Add object size method to gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ current_version = StorageServices.current_version('666') # where 666 is the id
 expect(current_version).to be_an_instance_of Integer
 ```
 
+#### Get Size of Moab Object
+```ruby
+object_size_in_bytes = StorageServices.object_size('666') # where 666 is the id
+expect(current_version).to be_an_instance_of Integer
+```
+
 ### Stanford-Specific
 
 #### Configuration
@@ -54,6 +60,13 @@ Note the below has "Stanford::StorageServices", which can be necessary if there 
 ```ruby
 current_version = Stanford::StorageServices.current_version('oo000oo0000') # where oo000oo0000 is the druid
 expect(current_version).to be_an_instance_of Integer
+```
+
+#### Get Size of Moab Object
+
+```ruby
+object_size_in_bytes = Stanford::StorageServices.object_size('oo000oo0000') # where oo000oo0000 is the druid
+expect(object_size_in_bytes).to be_an_instance_of Integer
 ```
 
 ## API Documentation

--- a/lib/moab/storage_repository.rb
+++ b/lib/moab/storage_repository.rb
@@ -102,6 +102,22 @@ module Moab
       storage_object
     end
 
+    # @param object_id [String] The identifier of the digital object whose size is desired
+    # @param include_deposit [Boolean] specifies whether to look in deposit areas for objects in process of initial ingest
+    # @return [Integer] the size occupied on disk by the storage object, in bytes.  this is the entire moab (all versions).
+    def object_size(object_id, include_deposit=false)
+      storage_pathname = find_storage_object(object_id, include_deposit).object_pathname
+      size = 0
+      Find.find(storage_pathname) do |path|
+        if FileTest.directory?(path)
+          Find.prune if File.basename(path)[0] == '.'
+        else
+          size += FileTest.size(path)
+        end
+      end
+      size
+    end
+
     # @param object_id [String] The identifier of the digital object whose version is desired
     # @param create [Boolean] If true, the object home directory should be created if it does not exist
     # @return [StorageObject] The representation of a digitial object's storage directory, which must exist.

--- a/lib/moab/storage_services.rb
+++ b/lib/moab/storage_services.rb
@@ -45,6 +45,13 @@ module Moab
       @@repository.find_storage_object(object_id, include_deposit)
     end
 
+    # @param object_id [String] The identifier of the digital object whose size is desired
+    # @param include_deposit [Boolean] specifies whether to look in deposit areas for objects in process of initial ingest
+    # @return [Integer] the size occupied on disk by the storage object, in bytes.  this is the entire moab (all versions).
+    def self.object_size(object_id, include_deposit=false)
+      @@repository.object_size(object_id, include_deposit)
+    end
+
     # @param object_id [String] The identifier of the digital object whose version is desired
     # @param create [Boolean] If true, the object home directory should be created if it does not exist
     # @return [StorageObject] The representation of a digitial object's storage directory, which must exist.

--- a/spec/unit_tests/moab/storage_repository_spec.rb
+++ b/spec/unit_tests/moab/storage_repository_spec.rb
@@ -57,13 +57,23 @@ describe 'Moab::StorageRepository' do
       allow(mock_storage_obj).to receive(:object_pathname).and_return(@mock_path)
       allow(@mock_path).to receive(:exist?).and_return(false)
     end
+
     it 'raises exception when object not found' do
       expect{storage_repo.storage_object('jq937jp0017')}.to raise_exception(Moab::ObjectNotFoundException)
     end
+
     it 'creates path when create set to true' do
       expect(@mock_path).to receive(:mkpath)
       storage_repo.storage_object('jq937jp0017', true)
     end
+  end
+
+  it '#object_size returns the size of a moab object' do
+    # values may differ from file system to file system (which is to be expected).
+    # if this test fails on your mac, make sure you don't have any extraneous .DS_Store files
+    # lingering in the fixture directories.
+    allow(storage_repo).to receive(:storage_branch).and_return('jq937jp0017')
+    expect(storage_repo.object_size('jq937jp0017')).to be_between(345_000, 346_000)
   end
 
   specify "#store_new_object_version" do

--- a/spec/unit_tests/moab/storage_services_spec.rb
+++ b/spec/unit_tests/moab/storage_services_spec.rb
@@ -49,6 +49,10 @@ describe 'Moab::StorageServices' do
     expect(Moab::StorageServices.current_version(@obj)).to eq 3
   end
 
+  specify '.object_size' do
+    expect(Moab::StorageServices.object_size(@obj)).to be_between(340000,350000)
+  end
+
   specify '.version_metadata' do
     vm_ng_xml = Nokogiri::XML(Moab::StorageServices.version_metadata(@obj).read)
     exp_xml = <<-EOF


### PR DESCRIPTION
- Add object size method to `Moab::StorageRepository`
- Updated README w/ usage

closes #21