### PR TITLE
unit_tests/moab/signature_catalog_entry_spec: remove cruft

### DIFF
--- a/spec/unit_tests/moab/signature_catalog_entry_spec.rb
+++ b/spec/unit_tests/moab/signature_catalog_entry_spec.rb
@@ -16,63 +16,11 @@ describe 'Moab::SignatureCatalogEntry' do
     expect(signature_catalog_entry.signature).to eq(opts[:signature])
   end
 
-  describe '=========================== INSTANCE ATTRIBUTES ===========================' do
-
-    before(:all) do
-      opts = {}
-      @signature_catalog_entry = Moab::SignatureCatalogEntry.new(opts)
-    end
-
-    # Unit test for attribute: {Moab::SignatureCatalogEntry#version_id}
-    # Which stores: [Integer] The ordinal version number
-    specify 'Moab::SignatureCatalogEntry#version_id' do
-      value = 8
-      @signature_catalog_entry.version_id= value
-      expect(@signature_catalog_entry.version_id).to eq(value)
-
-      # attribute :version_id, Integer, :tag => 'originalVersion', :key => true, :on_save => Proc.new {|n| n.to_s}
-    end
-
-    # Unit test for attribute: {Moab::SignatureCatalogEntry#group_id}
-    # Which stores: [String] The name of the file group
-    specify 'Moab::SignatureCatalogEntry#group_id' do
-      value = 'Test group_id'
-      @signature_catalog_entry.group_id= value
-      expect(@signature_catalog_entry.group_id).to eq(value)
-
-      # attribute :group_id, String, :tag => 'groupId', :key => true
-    end
-
-    # Unit test for attribute: {Moab::SignatureCatalogEntry#path}
-    # Which stores: [String] The id is the filename path, relative to the file group's base directory
-    specify 'Moab::SignatureCatalogEntry#path' do
-      value = 'Test path'
-      @signature_catalog_entry.path= value
-      expect(@signature_catalog_entry.path).to eq(value)
-
-      # attribute :path, String, :key => true, :tag => 'storagePath'
-    end
-
-    # Unit test for attribute: {Moab::SignatureCatalogEntry#signature}
-    # Which stores: [Moab::FileSignature] The fixity data of the file instance
-    specify 'Moab::SignatureCatalogEntry#signature' do
-      value = double(Moab::FileSignature.name)
-      @signature_catalog_entry.signature= value
-      expect(@signature_catalog_entry.signature).to eq(value)
-
-      @signature_catalog_entry.signature= [value, 'dummy']
-      expect(@signature_catalog_entry.signature).to eq(value)
-
-      # def signature=(signature)
-      #   @signature = signature.is_a?(Array) ? signature[0] : signature
-      # end
-
-      # def signature
-      #   # HappyMapper's parser tries to put an array of signatures in the signature field
-      #   @signature.is_a?(Array) ? @signature[0] : @signature
-      # end
-    end
-
+  specify '#signature becomes first value if set to Array' do
+    sce = Moab::SignatureCatalogEntry.new()
+    value = double(Moab::FileSignature.name)
+    sce.signature = [value, 'dummy']
+    expect(sce.signature).to eq value
   end
 
   describe '=========================== INSTANCE METHODS ===========================' do

--- a/spec/unit_tests/moab/signature_catalog_entry_spec.rb
+++ b/spec/unit_tests/moab/signature_catalog_entry_spec.rb
@@ -1,39 +1,19 @@
 require 'spec_helper'
 
-# Unit tests for class {Moab::SignatureCatalogEntry}
 describe 'Moab::SignatureCatalogEntry' do
 
-  describe '=========================== CONSTRUCTOR ===========================' do
-
-    # Unit test for constructor: {Moab::SignatureCatalogEntry#initialize}
-    # Which returns an instance of: [Moab::SignatureCatalogEntry]
-    # For input parameters:
-    # * opts [Hash<Symbol,Object>] = a hash containing any number of symbol => value pairs. The symbols should
-    #  correspond to attributes declared using HappyMapper syntax
-    specify 'Moab::SignatureCatalogEntry#initialize' do
-
-      # test initialization with required parameters (if any)
-      opts = {}
-      signature_catalog_entry = Moab::SignatureCatalogEntry.new(opts)
-      expect(signature_catalog_entry).to be_instance_of(Moab::SignatureCatalogEntry)
-
-      # test initialization with options hash
-      opts = Hash.new
-      opts[:version_id] = 26
-      opts[:group_id] = 'Test group_id'
-      opts[:path] = 'Test path'
-      opts[:signature] = double(Moab::FileSignature.name)
-      signature_catalog_entry = Moab::SignatureCatalogEntry.new(opts)
-      expect(signature_catalog_entry.version_id).to eq(opts[:version_id])
-      expect(signature_catalog_entry.group_id).to eq(opts[:group_id])
-      expect(signature_catalog_entry.path).to eq(opts[:path])
-      expect(signature_catalog_entry.signature).to eq(opts[:signature])
-
-      # def initialize(opts={})
-      #   super(opts)
-      # end
-    end
-
+  specify '#initialize' do
+    opts = {
+      version_id: 26,
+      group_id: 'Test group_id',
+      path: 'Test path',
+      signature: double(Moab::FileSignature.name)
+    }
+    signature_catalog_entry = Moab::SignatureCatalogEntry.new(opts)
+    expect(signature_catalog_entry.version_id).to eq(opts[:version_id])
+    expect(signature_catalog_entry.group_id).to eq(opts[:group_id])
+    expect(signature_catalog_entry.path).to eq(opts[:path])
+    expect(signature_catalog_entry.signature).to eq(opts[:signature])
   end
 
   describe '=========================== INSTANCE ATTRIBUTES ===========================' do

--- a/spec/unit_tests/moab/signature_catalog_entry_spec.rb
+++ b/spec/unit_tests/moab/signature_catalog_entry_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe 'Moab::SignatureCatalogEntry' do
 
+  let(:sce) { Moab::SignatureCatalogEntry.new() }
+
   specify '#initialize' do
     opts = {
       version_id: 26,
@@ -17,35 +19,15 @@ describe 'Moab::SignatureCatalogEntry' do
   end
 
   specify '#signature becomes first value if set to Array' do
-    sce = Moab::SignatureCatalogEntry.new()
     value = double(Moab::FileSignature.name)
     sce.signature = [value, 'dummy']
     expect(sce.signature).to eq value
   end
 
-  describe '=========================== INSTANCE METHODS ===========================' do
-
-    before(:each) do
-      @opts = {}
-      @signature_catalog_entry = Moab::SignatureCatalogEntry.new(@opts)
-
-      @signature_catalog_entry.version_id = 5
-      @signature_catalog_entry.group_id = 'content'
-      @signature_catalog_entry.path = 'title.jpg'
-      @signature_catalog_entry.signature = double(Moab::FileSignature.name)
-    end
-
-    # Unit test for method: {Moab::SignatureCatalogEntry#storage_path}
-    # Which returns: [String] Returns the storage path to a file, relative to the object storage home directory
-    # For input parameters: (None)
-    specify 'Moab::SignatureCatalogEntry#storage_path' do
-      expect(@signature_catalog_entry.storage_path()).to eq("v0005/data/content/title.jpg")
-
-      # def storage_path
-      #   File.join(Moab::StorageObject.version_dirname(version_id),'data', group_id, path)
-      # end
-    end
-
+  specify '#storage_path' do
+    sce.version_id = 5
+    sce.group_id = 'content'
+    sce.path = 'title.jpg'
+    expect(sce.storage_path()).to eq("v0005/data/content/title.jpg")
   end
-
 end


### PR DESCRIPTION
Please review especially for:

 - no useful tests removed (some pointless ones have been removed)
 - no existing test functionality has been changed (refactored some variable names or avoided long lines or changed otherwise for readability)

This spec cleanup:

- shortens names of specs to be just the method names
- removes comments containing the rdoc or implementation of methods
- removes specs that are useless (e.g. that setting an attribute value means you can retrieve the attribute value; that instantiating an object returns an instance of the object)
- splits out multiple tests in a single spec into separate tests
- avoids long lines
- refactors variable names for clarity
- removes unnecessary @ variables
- tried to follow principles to make rubocop happier
etc.

