### PR TITLE
unit_tests/moab/file_manifestation_spec: remove cruft

### DIFF
--- a/spec/unit_tests/moab/file_manifestation_spec.rb
+++ b/spec/unit_tests/moab/file_manifestation_spec.rb
@@ -1,6 +1,21 @@
 require 'spec_helper'
 
 describe 'Moab::FileManifestation' do
+  let(:file_manifestation) do
+    v1_base_directory = @fixtures.join('data/jq937jp0017/v0001/content')
+    title_v1_pathname = @fixtures.join('data/jq937jp0017/v0001/content/title.jpg')
+    page1_v1_pathname = @fixtures.join('data/jq937jp0017/v0001/content/page-1.jpg')
+
+    title_v1_signature = Moab::FileSignature.new.signature_from_file(title_v1_pathname)
+    title_v1_instance = Moab::FileInstance.new.instance_from_file(title_v1_pathname, v1_base_directory)
+    page1_v1_instance = Moab::FileInstance.new.instance_from_file(page1_v1_pathname, v1_base_directory)
+
+    fm = Moab::FileManifestation.new
+    fm.signature = title_v1_signature
+    fm.instances << title_v1_instance
+    fm.instances << page1_v1_instance
+    fm
+  end
 
   describe '#initialize' do
     specify 'empty options hash' do
@@ -19,7 +34,6 @@ describe 'Moab::FileManifestation' do
   end
 
   describe '#signature' do
-    let(:file_manifestation) { Moab::FileManifestation.new }
     let(:value) { double(Moab::FileSignature.name) }
 
     specify 'single value' do
@@ -30,22 +44,6 @@ describe 'Moab::FileManifestation' do
       file_manifestation.signature = [value]
       expect(file_manifestation.signature).to eq value
     end
-  end
-
-  let(:file_manifestation) do
-    v1_base_directory = @fixtures.join('data/jq937jp0017/v0001/content')
-    title_v1_pathname = @fixtures.join('data/jq937jp0017/v0001/content/title.jpg')
-    page1_v1_pathname = @fixtures.join('data/jq937jp0017/v0001/content/page-1.jpg')
-
-    title_v1_signature = Moab::FileSignature.new.signature_from_file(title_v1_pathname)
-    title_v1_instance = Moab::FileInstance.new.instance_from_file(title_v1_pathname, v1_base_directory)
-    page1_v1_instance = Moab::FileInstance.new.instance_from_file(page1_v1_pathname, v1_base_directory)
-
-    fm = Moab::FileManifestation.new
-    fm.signature = title_v1_signature
-    fm.instances << title_v1_instance
-    fm.instances << page1_v1_instance
-    fm
   end
 
   specify '#paths' do

--- a/spec/unit_tests/moab/file_manifestation_spec.rb
+++ b/spec/unit_tests/moab/file_manifestation_spec.rb
@@ -1,46 +1,30 @@
 require 'spec_helper'
 
-# Unit tests for class {Moab::FileManifestation}
 describe 'Moab::FileManifestation' do
 
-  describe '=========================== CONSTRUCTOR ===========================' do
-
-    # Unit test for constructor: {Moab::FileManifestation#initialize}
-    # Which returns an instance of: [Moab::FileManifestation]
-    # For input parameters:
-    # * opts [Hash<Symbol,Object>] = a hash containing any number of symbol => value pairs. The symbols should
-    #  correspond to attributes declared using HappyMapper syntax
-    specify 'Moab::FileManifestation#initialize' do
-
-      # test initialization with required parameters (if any)
-      opts = {}
-      file_manifestation = Moab::FileManifestation.new(opts)
-      expect(file_manifestation).to be_instance_of(Moab::FileManifestation)
-      expect(file_manifestation.instances).to be_instance_of(Array)
-
-      # test initialization with options hash
-      opts = Hash.new
-      opts[:signature] = double(Moab::FileSignature.name)
-      opts[:instances] = double(Moab::FileInstance.name)
-      file_manifestation = Moab::FileManifestation.new(opts)
-      expect(file_manifestation.signature).to eq(opts[:signature])
-      expect(file_manifestation.instances).to eq(opts[:instances])
-       
-      # def initialize(opts={})
-      #   @instances = Array.new
-      #   super(opts)
-      # end
+  describe '#initialize' do
+    specify 'empty options hash' do
+      file_manifestation = Moab::FileManifestation.new({})
+      expect(file_manifestation.instances).to be_instance_of Array
     end
-  
+    specify 'options passed in' do
+      opts = {
+        signature: double(Moab::FileSignature.name),
+        instances: double(Moab::FileInstance.name)
+      }
+      file_manifestation = Moab::FileManifestation.new(opts)
+      expect(file_manifestation.signature).to eq opts[:signature]
+      expect(file_manifestation.instances).to eq opts[:instances]
+    end
   end
-  
+
   describe '=========================== INSTANCE ATTRIBUTES ===========================' do
-    
+
     before(:all) do
       opts = {}
       @file_manifestation = Moab::FileManifestation.new(opts)
     end
-    
+
     # Unit test for attribute: {Moab::FileManifestation#signature}
     # Which stores: [Moab::FileSignature] The fixity data of the file instance
     specify 'Moab::FileManifestation#signature' do
@@ -53,26 +37,26 @@ describe 'Moab::FileManifestation' do
       # def signature=(signature)
       #   @signature = signature.is_a?(Array) ? signature[0] : signature
       # end
-       
+
       # def signature
       #   @signature.is_a?(Array) ? @signature[0] : @signature
       # end
     end
-    
+
     # Unit test for attribute: {Moab::FileManifestation#instances}
     # Which stores: [Array<Moab::FileInstance>] The location(s) of the file manifestation's file instances
     specify 'Moab::FileManifestation#instances' do
       value = double(Moab::FileInstance.name)
       @file_manifestation.instances= value
       expect(@file_manifestation.instances).to eq(value)
-       
+
       # has_many :instances, Moab::FileInstance
     end
-  
+
   end
-  
+
   describe '=========================== INSTANCE METHODS ===========================' do
-    
+
     before(:each) do
       @v1_base_directory = @fixtures.join('data/jq937jp0017/v0001/content')
       @title_v1_pathname = @fixtures.join('data/jq937jp0017/v0001/content/title.jpg')
@@ -90,46 +74,46 @@ describe 'Moab::FileManifestation' do
       @file_manifestation.instances << @title_v1_instance
       @file_manifestation.instances << @page1_v1_instance
     end
-    
+
     # Unit test for method: {Moab::FileManifestation#paths}
     # Which returns: [Array<String>] Create an array from all the file paths of the child {Moab::FileInstance} objects
     # For input parameters: (None)
     specify 'Moab::FileManifestation#paths' do
       expect(@file_manifestation.paths()).to eq(["title.jpg", "page-1.jpg"])
-       
+
       # def paths
       #   instances.collect { |i| i.path}
       # end
     end
-    
+
     # Unit test for method: {Moab::FileManifestation#file_count}
     # Which returns: [Integer] The total number of {Moab::FileInstance} objects in this manifestation.
     #  (Number of files that share this manifestation's signature)
     specify 'Moab::FileManifestation#file_count' do
       expect(@file_manifestation.file_count()).to eq(2)
-       
+
       # def file_count
       #   instances.size
       # end
     end
-    
+
     # Unit test for method: {Moab::FileManifestation#byte_count}
     # Which returns: [Integer] The total size (in bytes) of all files that share this manifestation's signature
     # For input parameters: (None)
     specify 'Moab::FileManifestation#byte_count' do
       expect(@file_manifestation.byte_count()).to eq(81746)
-       
+
       # def byte_count
       #   file_count.to_i * signature.size.to_i
       # end
     end
-    
+
     # Unit test for method: {Moab::FileManifestation#block_count}
     # Which returns: [Integer] The total disk usage (in 1 kB blocks) of all files that share this manifestation's signature (estimating du -k result)
     # For input parameters: (None)
     specify 'Moab::FileManifestation#block_count' do
       expect(@file_manifestation.block_count()).to eq(80)
-       
+
       # def block_count
       #   block_size=1024
       #   instance_blocks = (signature.size.to_i + block_size - 1)/block_size
@@ -149,7 +133,7 @@ describe 'Moab::FileManifestation' do
       #   (self.signature == other.signature) && (self.instances == other.instances)
       # end
     end
-  
+
   end
 
 end

--- a/spec/unit_tests/moab/file_manifestation_spec.rb
+++ b/spec/unit_tests/moab/file_manifestation_spec.rb
@@ -19,7 +19,7 @@ describe 'Moab::FileManifestation' do
   end
 
   describe '#signature' do
-    let(:file_manifestation) { Moab::FileManifestation.new({}) }
+    let(:file_manifestation) { Moab::FileManifestation.new }
     let(:value) { double(Moab::FileSignature.name) }
 
     specify 'single value' do
@@ -32,85 +32,40 @@ describe 'Moab::FileManifestation' do
     end
   end
 
-  describe '=========================== INSTANCE METHODS ===========================' do
+  let(:file_manifestation) do
+    v1_base_directory = @fixtures.join('data/jq937jp0017/v0001/content')
+    title_v1_pathname = @fixtures.join('data/jq937jp0017/v0001/content/title.jpg')
+    page1_v1_pathname = @fixtures.join('data/jq937jp0017/v0001/content/page-1.jpg')
 
-    before(:each) do
-      @v1_base_directory = @fixtures.join('data/jq937jp0017/v0001/content')
-      @title_v1_pathname = @fixtures.join('data/jq937jp0017/v0001/content/title.jpg')
-      @page1_v1_pathname = @fixtures.join('data/jq937jp0017/v0001/content/page-1.jpg')
+    title_v1_signature = Moab::FileSignature.new.signature_from_file(title_v1_pathname)
+    title_v1_instance = Moab::FileInstance.new.instance_from_file(title_v1_pathname, v1_base_directory)
+    page1_v1_instance = Moab::FileInstance.new.instance_from_file(page1_v1_pathname, v1_base_directory)
 
-      @title_v1_signature = Moab::FileSignature.new.signature_from_file(@title_v1_pathname)
-
-      @title_v1_instance = Moab::FileInstance.new.instance_from_file(@title_v1_pathname,@v1_base_directory)
-      @page1_v1_instance = Moab::FileInstance.new.instance_from_file(@page1_v1_pathname,@v1_base_directory)
-
-      @opts = {}
-      @file_manifestation = Moab::FileManifestation.new(@opts)
-
-      @file_manifestation.signature = @title_v1_signature
-      @file_manifestation.instances << @title_v1_instance
-      @file_manifestation.instances << @page1_v1_instance
-    end
-
-    # Unit test for method: {Moab::FileManifestation#paths}
-    # Which returns: [Array<String>] Create an array from all the file paths of the child {Moab::FileInstance} objects
-    # For input parameters: (None)
-    specify 'Moab::FileManifestation#paths' do
-      expect(@file_manifestation.paths()).to eq(["title.jpg", "page-1.jpg"])
-
-      # def paths
-      #   instances.collect { |i| i.path}
-      # end
-    end
-
-    # Unit test for method: {Moab::FileManifestation#file_count}
-    # Which returns: [Integer] The total number of {Moab::FileInstance} objects in this manifestation.
-    #  (Number of files that share this manifestation's signature)
-    specify 'Moab::FileManifestation#file_count' do
-      expect(@file_manifestation.file_count()).to eq(2)
-
-      # def file_count
-      #   instances.size
-      # end
-    end
-
-    # Unit test for method: {Moab::FileManifestation#byte_count}
-    # Which returns: [Integer] The total size (in bytes) of all files that share this manifestation's signature
-    # For input parameters: (None)
-    specify 'Moab::FileManifestation#byte_count' do
-      expect(@file_manifestation.byte_count()).to eq(81746)
-
-      # def byte_count
-      #   file_count.to_i * signature.size.to_i
-      # end
-    end
-
-    # Unit test for method: {Moab::FileManifestation#block_count}
-    # Which returns: [Integer] The total disk usage (in 1 kB blocks) of all files that share this manifestation's signature (estimating du -k result)
-    # For input parameters: (None)
-    specify 'Moab::FileManifestation#block_count' do
-      expect(@file_manifestation.block_count()).to eq(80)
-
-      # def block_count
-      #   block_size=1024
-      #   instance_blocks = (signature.size.to_i + block_size - 1)/block_size
-      #   file_count * instance_blocks
-      # end
-    end
-
-    # Unit test for method: {Moab::FileManifestation#==}
-    # Which returns: [Boolean] True if {Moab::FileManifestation} objects have same content
-    # For input parameters:
-    # * other [Moab::FileManifestation] = The {Moab::FileManifestation} object to compare with self
-    specify 'Moab::FileManifestation#==' do
-      other = @file_manifestation
-      expect(@file_manifestation.==(other)).to eq(true)
-
-      # def ==(other)
-      #   (self.signature == other.signature) && (self.instances == other.instances)
-      # end
-    end
-
+    fm = Moab::FileManifestation.new
+    fm.signature = title_v1_signature
+    fm.instances << title_v1_instance
+    fm.instances << page1_v1_instance
+    fm
   end
 
+  specify '#paths' do
+    expect(file_manifestation.paths()).to eq ["title.jpg", "page-1.jpg"]
+  end
+
+  specify '#file_count' do
+    expect(file_manifestation.file_count()).to eq 2
+  end
+
+  specify '#byte_count' do
+    expect(file_manifestation.byte_count()).to eq 81746
+  end
+
+  specify '#block_count' do
+    expect(file_manifestation.block_count()).to eq 80
+  end
+
+  specify '#==' do
+    other = file_manifestation
+    expect(file_manifestation == other).to eq true
+  end
 end

--- a/spec/unit_tests/moab/file_manifestation_spec.rb
+++ b/spec/unit_tests/moab/file_manifestation_spec.rb
@@ -18,41 +18,18 @@ describe 'Moab::FileManifestation' do
     end
   end
 
-  describe '=========================== INSTANCE ATTRIBUTES ===========================' do
+  describe '#signature' do
+    let(:file_manifestation) { Moab::FileManifestation.new({}) }
+    let(:value) { double(Moab::FileSignature.name) }
 
-    before(:all) do
-      opts = {}
-      @file_manifestation = Moab::FileManifestation.new(opts)
+    specify 'single value' do
+      file_manifestation.signature = value
+      expect(file_manifestation.signature).to eq value
     end
-
-    # Unit test for attribute: {Moab::FileManifestation#signature}
-    # Which stores: [Moab::FileSignature] The fixity data of the file instance
-    specify 'Moab::FileManifestation#signature' do
-      value = double(Moab::FileSignature.name)
-      @file_manifestation.signature= value
-      expect(@file_manifestation.signature).to eq(value)
-      @file_manifestation.signature= [value]
-      expect(@file_manifestation.signature).to eq(value)
-
-      # def signature=(signature)
-      #   @signature = signature.is_a?(Array) ? signature[0] : signature
-      # end
-
-      # def signature
-      #   @signature.is_a?(Array) ? @signature[0] : @signature
-      # end
+    specify 'becomes first value if set to Array of values' do
+      file_manifestation.signature = [value]
+      expect(file_manifestation.signature).to eq value
     end
-
-    # Unit test for attribute: {Moab::FileManifestation#instances}
-    # Which stores: [Array<Moab::FileInstance>] The location(s) of the file manifestation's file instances
-    specify 'Moab::FileManifestation#instances' do
-      value = double(Moab::FileInstance.name)
-      @file_manifestation.instances= value
-      expect(@file_manifestation.instances).to eq(value)
-
-      # has_many :instances, Moab::FileInstance
-    end
-
   end
 
   describe '=========================== INSTANCE METHODS ===========================' do


### PR DESCRIPTION
Please review especially for:
- no useful tests removed  (some pointless ones have been removed)
- no existing test functionality has been changed (refactored some variable names or avoided long lines or changed otherwise for readability)

This spec cleanup:

- shortens names of specs to be just the method names
- removes comments containing the rdoc or implementation of methods
- removes specs that are useless  (e.g. that setting an attribute value means you can retrieve the attribute value;  that instantiating an object returns an instance of the object)
- splits out multiple tests in a single spec into separate tests
- avoids long lines
- refactors variable names for clarity
- removes unnecessary @ variables
- tried to follow principles to make rubocop happier
etc.
