### PR TITLE
unit_tests/moab/file_instance_spec: remove cruft

### DIFF
--- a/spec/unit_tests/moab/file_instance_spec.rb
+++ b/spec/unit_tests/moab/file_instance_spec.rb
@@ -1,68 +1,48 @@
 require 'spec_helper'
 
-# Unit tests for class {Moab::FileInstance}
 describe 'Moab::FileInstance' do
 
-  describe '=========================== CONSTRUCTOR ===========================' do
-
-    # Unit test for constructor: {Moab::FileInstance#initialize}
-    # Which returns an instance of: [Moab::FileInstance]
-    # For input parameters:
-    # * opts [Hash<Symbol,Object>] = a hash containing any number of symbol => value pairs. The symbols should
-    #   correspond to attributes declared using HappyMapper syntax
-    specify 'Moab::FileInstance#initialize' do
-
-      # test initialization with required parameters (if any)
-      opts = {}
-      file_instance = Moab::FileInstance.new(opts)
-      expect(file_instance).to be_instance_of(Moab::FileInstance)
-
-      # test initialization with options hash
-      opts = Hash.new
-      opts[:path] = @temp.join('path').to_s
-      opts[:datetime] = "Apr 18 21:51:31 UTC 2012"
-      file_instance = Moab::FileInstance.new(opts)
-      expect(file_instance.path).to eq(opts[:path])
-      expect(file_instance.datetime).to eq("2012-04-18T21:51:31Z")
-       
-      # def initialize(opts={})
-      #   super(opts)
-      # end
-    end
-  
+  specify '#initialize' do
+    opts = {
+      path: @temp.join('path').to_s,
+      datetime: "Apr 18 21:51:31 UTC 2012"
+    }
+    file_instance = Moab::FileInstance.new(opts)
+    expect(file_instance.path).to eq opts[:path]
+    expect(file_instance.datetime).to eq "2012-04-18T21:51:31Z"
   end
-  
+
   describe '=========================== INSTANCE ATTRIBUTES ===========================' do
-    
+
     before(:all) do
       opts = {}
       @file_instance = Moab::FileInstance.new(opts)
     end
-    
+
     # Unit test for attribute: {Moab::FileInstance#path}
     # Which stores: [String] \@ = The id is the filename path, relative to the file group's base directory
     specify 'Moab::FileInstance#path' do
       value = 'Test path'
       @file_instance.path= value
       expect(@file_instance.path).to eq(value)
-       
+
       # attribute :path, String, :key => true
     end
-    
+
     # Unit test for attribute: {Moab::FileInstance#datetime}
     # Which stores: [Time] \@ = gsub(/\n/,' ')
     specify 'Moab::FileInstance#datetime' do
       value = "Wed Apr 18 21:51:31 UTC 2012"
       @file_instance.datetime= value
       expect(@file_instance.datetime).to eq("2012-04-18T21:51:31Z")
-       
+
       # attribute :datetime, Time, :on_save => Proc.new {|t| t.to_s}
     end
-  
+
   end
-  
+
   describe '=========================== INSTANCE METHODS ===========================' do
-    
+
     before(:each) do
       @v1_base_directory = @fixtures.join('data/jq937jp0017/v0001/content')
       @title_v1_pathname = @fixtures.join('data/jq937jp0017/v0001/content/title.jpg')
@@ -75,9 +55,9 @@ describe 'Moab::FileInstance' do
       @title_v2_instance = Moab::FileInstance.new.instance_from_file(@title_v2_pathname,@v2_base_directory)
       @page1_v1_instance = Moab::FileInstance.new.instance_from_file(@page1_v1_pathname,@v1_base_directory)
       @page1_v2_instance = Moab::FileInstance.new.instance_from_file(@page1_v2_pathname,@v2_base_directory)
-      
+
     end
-    
+
     # Unit test for method: {Moab::FileInstance#instance_from_file}
     # Which returns: [Moab::FileInstance] Returns a file instance containing a physical file's' properties
     # For input parameters:
@@ -88,18 +68,18 @@ describe 'Moab::FileInstance' do
       file_instance = Moab::FileInstance.new.instance_from_file(@title_v1_pathname,@v1_base_directory)
       expect(file_instance.path).to eq("title.jpg")
       expect(file_instance.datetime).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/)
-       
+
       # def instance_from_file(pathname, base_directory)
       #   @path = pathname.realpath.relative_path_from(base_directory.realpath).to_s
       #   @datetime = pathname.mtime.iso8601
       #   self
       # end
     end
-    
+
     # Unit test for method: {Moab::FileInstance#eql?}
     # Which returns: [Boolean] Returns true if self and other have the same path.
     # For input parameters:
-    # * other [Moab::FileInstance] = The other file instance being compared to this instance 
+    # * other [Moab::FileInstance] = The other file instance being compared to this instance
     specify 'Moab::FileInstance#eql?' do
       expect(@title_v1_instance.eql?(@title_v2_instance)).to eq(true)
       expect(@page1_v1_instance.eql?(@page1_v2_instance)).to eq(true)
@@ -109,11 +89,11 @@ describe 'Moab::FileInstance' do
       #   self.path == other.path
       # end
     end
-    
+
     # Unit test for method: {Moab::FileInstance#==}
     # Which returns: [Boolean] Returns true if self and other have the same path.
     # For input parameters:
-    # * other [Moab::FileInstance] = The other file instance being compared to this instance 
+    # * other [Moab::FileInstance] = The other file instance being compared to this instance
     specify 'Moab::FileInstance#==' do
       expect(@title_v1_instance == @title_v2_instance).to eq(true)
       expect(@page1_v1_instance == @page1_v2_instance).to eq(true)
@@ -123,7 +103,7 @@ describe 'Moab::FileInstance' do
       #   eql?(other)
       # end
     end
-    
+
     # Unit test for method: {Moab::FileInstance#hash}
     # Which returns: [Fixnum] Compute a hash-code for the path string.
     # For input parameters: (None)
@@ -131,12 +111,12 @@ describe 'Moab::FileInstance' do
       expect(@title_v1_instance.hash == @title_v2_instance.hash).to eq(true)
       expect(@page1_v1_instance.hash == @page1_v2_instance.hash).to eq(true)
       expect(@title_v1_instance.hash == @page1_v2_instance.hash).to eq(false)
-       
+
       # def hash
       #   path.hash
       # end
     end
-  
+
   end
 
 end

--- a/spec/unit_tests/moab/file_instance_spec.rb
+++ b/spec/unit_tests/moab/file_instance_spec.rb
@@ -19,82 +19,45 @@ describe 'Moab::FileInstance' do
     expect(fi.datetime).to eq "2012-04-18T21:51:31Z"
   end
 
-  describe '=========================== INSTANCE METHODS ===========================' do
-
-    before(:each) do
-      @v1_base_directory = @fixtures.join('data/jq937jp0017/v0001/content')
-      @title_v1_pathname = @fixtures.join('data/jq937jp0017/v0001/content/title.jpg')
-      @title_v2_pathname = @fixtures.join('data/jq937jp0017/v0002/content/title.jpg')
-      @v2_base_directory = @fixtures.join('data/jq937jp0017/v0002/content')
-      @page1_v1_pathname = @fixtures.join('data/jq937jp0017/v0001/content/page-1.jpg')
-      @page1_v2_pathname = @fixtures.join('data/jq937jp0017/v0002/content/page-1.jpg')
-
-      @title_v1_instance = Moab::FileInstance.new.instance_from_file(@title_v1_pathname,@v1_base_directory)
-      @title_v2_instance = Moab::FileInstance.new.instance_from_file(@title_v2_pathname,@v2_base_directory)
-      @page1_v1_instance = Moab::FileInstance.new.instance_from_file(@page1_v1_pathname,@v1_base_directory)
-      @page1_v2_instance = Moab::FileInstance.new.instance_from_file(@page1_v2_pathname,@v2_base_directory)
-
-    end
-
-    # Unit test for method: {Moab::FileInstance#instance_from_file}
-    # Which returns: [Moab::FileInstance] Returns a file instance containing a physical file's' properties
-    # For input parameters:
-    # * pathname [Pathname] = The location of the physical file
-    # * base_directory [Pathname] The full path used as the basis of the relative paths reported
-
-    specify 'Moab::FileInstance#instance_from_file' do
-      file_instance = Moab::FileInstance.new.instance_from_file(@title_v1_pathname,@v1_base_directory)
-      expect(file_instance.path).to eq("title.jpg")
-      expect(file_instance.datetime).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/)
-
-      # def instance_from_file(pathname, base_directory)
-      #   @path = pathname.realpath.relative_path_from(base_directory.realpath).to_s
-      #   @datetime = pathname.mtime.iso8601
-      #   self
-      # end
-    end
-
-    # Unit test for method: {Moab::FileInstance#eql?}
-    # Which returns: [Boolean] Returns true if self and other have the same path.
-    # For input parameters:
-    # * other [Moab::FileInstance] = The other file instance being compared to this instance
-    specify 'Moab::FileInstance#eql?' do
-      expect(@title_v1_instance.eql?(@title_v2_instance)).to eq(true)
-      expect(@page1_v1_instance.eql?(@page1_v2_instance)).to eq(true)
-      expect(@title_v1_instance.eql?(@page1_v2_instance)).to eq(false)
-
-      # def eql?(other)
-      #   self.path == other.path
-      # end
-    end
-
-    # Unit test for method: {Moab::FileInstance#==}
-    # Which returns: [Boolean] Returns true if self and other have the same path.
-    # For input parameters:
-    # * other [Moab::FileInstance] = The other file instance being compared to this instance
-    specify 'Moab::FileInstance#==' do
-      expect(@title_v1_instance == @title_v2_instance).to eq(true)
-      expect(@page1_v1_instance == @page1_v2_instance).to eq(true)
-      expect(@title_v1_instance == @page1_v2_instance).to eq(false)
-
-      # def ==(other)
-      #   eql?(other)
-      # end
-    end
-
-    # Unit test for method: {Moab::FileInstance#hash}
-    # Which returns: [Fixnum] Compute a hash-code for the path string.
-    # For input parameters: (None)
-    specify 'Moab::FileInstance#hash' do
-      expect(@title_v1_instance.hash == @title_v2_instance.hash).to eq(true)
-      expect(@page1_v1_instance.hash == @page1_v2_instance.hash).to eq(true)
-      expect(@title_v1_instance.hash == @page1_v2_instance.hash).to eq(false)
-
-      # def hash
-      #   path.hash
-      # end
-    end
-
+  let(:v1_base_directory) { @fixtures.join('data/jq937jp0017/v0001/content') }
+  let(:v2_base_directory) { @fixtures.join('data/jq937jp0017/v0002/content') }
+  let(:title_v1_instance) do
+    title_v1_pathname = @fixtures.join('data/jq937jp0017/v0001/content/title.jpg')
+    Moab::FileInstance.new.instance_from_file(title_v1_pathname, v1_base_directory)
+  end
+  let(:title_v2_instance) do
+    title_v2_pathname = @fixtures.join('data/jq937jp0017/v0002/content/title.jpg')
+    Moab::FileInstance.new.instance_from_file(title_v2_pathname, v2_base_directory)
+  end
+  let(:page1_v1_instance) do
+    page1_v1_pathname = @fixtures.join('data/jq937jp0017/v0001/content/page-1.jpg')
+    Moab::FileInstance.new.instance_from_file(page1_v1_pathname, v1_base_directory)
+  end
+  let(:page1_v2_instance) do
+    page1_v2_pathname = @fixtures.join('data/jq937jp0017/v0002/content/page-1.jpg')
+    Moab::FileInstance.new.instance_from_file(page1_v2_pathname, v2_base_directory)
   end
 
+  specify '#instance_from_file' do
+    expect(title_v1_instance.path).to eq "title.jpg"
+    expect(title_v1_instance.datetime).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/)
+  end
+
+  specify '#eql?' do
+    expect(title_v1_instance.eql?(title_v2_instance)).to eq true
+    expect(page1_v1_instance.eql?(page1_v2_instance)).to eq true
+    expect(title_v1_instance.eql?(page1_v2_instance)).to eq false
+  end
+
+  specify '#==' do
+    expect(title_v1_instance == title_v2_instance).to eq true
+    expect(page1_v1_instance == page1_v2_instance).to eq true
+    expect(title_v1_instance == page1_v2_instance).to eq false
+  end
+
+  specify '#hash' do
+    expect(title_v1_instance.hash == title_v2_instance.hash).to eq true
+    expect(page1_v1_instance.hash == page1_v2_instance.hash).to eq true
+    expect(title_v1_instance.hash == page1_v2_instance.hash).to eq false
+  end
 end

--- a/spec/unit_tests/moab/file_instance_spec.rb
+++ b/spec/unit_tests/moab/file_instance_spec.rb
@@ -12,33 +12,11 @@ describe 'Moab::FileInstance' do
     expect(file_instance.datetime).to eq "2012-04-18T21:51:31Z"
   end
 
-  describe '=========================== INSTANCE ATTRIBUTES ===========================' do
-
-    before(:all) do
-      opts = {}
-      @file_instance = Moab::FileInstance.new(opts)
-    end
-
-    # Unit test for attribute: {Moab::FileInstance#path}
-    # Which stores: [String] \@ = The id is the filename path, relative to the file group's base directory
-    specify 'Moab::FileInstance#path' do
-      value = 'Test path'
-      @file_instance.path= value
-      expect(@file_instance.path).to eq(value)
-
-      # attribute :path, String, :key => true
-    end
-
-    # Unit test for attribute: {Moab::FileInstance#datetime}
-    # Which stores: [Time] \@ = gsub(/\n/,' ')
-    specify 'Moab::FileInstance#datetime' do
-      value = "Wed Apr 18 21:51:31 UTC 2012"
-      @file_instance.datetime= value
-      expect(@file_instance.datetime).to eq("2012-04-18T21:51:31Z")
-
-      # attribute :datetime, Time, :on_save => Proc.new {|t| t.to_s}
-    end
-
+  specify '#datetime reformats as ISO8601 (UTC Z format)' do
+    fi = Moab::FileInstance.new
+    value = "Wed Apr 18 21:51:31 UTC 2012"
+    fi.datetime = value
+    expect(fi.datetime).to eq "2012-04-18T21:51:31Z"
   end
 
   describe '=========================== INSTANCE METHODS ===========================' do

--- a/spec/unit_tests/moab/file_instance_spec.rb
+++ b/spec/unit_tests/moab/file_instance_spec.rb
@@ -1,24 +1,6 @@
 require 'spec_helper'
 
 describe 'Moab::FileInstance' do
-
-  specify '#initialize' do
-    opts = {
-      path: @temp.join('path').to_s,
-      datetime: "Apr 18 21:51:31 UTC 2012"
-    }
-    file_instance = Moab::FileInstance.new(opts)
-    expect(file_instance.path).to eq opts[:path]
-    expect(file_instance.datetime).to eq "2012-04-18T21:51:31Z"
-  end
-
-  specify '#datetime reformats as ISO8601 (UTC Z format)' do
-    fi = Moab::FileInstance.new
-    value = "Wed Apr 18 21:51:31 UTC 2012"
-    fi.datetime = value
-    expect(fi.datetime).to eq "2012-04-18T21:51:31Z"
-  end
-
   let(:v1_base_directory) { @fixtures.join('data/jq937jp0017/v0001/content') }
   let(:v2_base_directory) { @fixtures.join('data/jq937jp0017/v0002/content') }
   let(:title_v1_instance) do
@@ -36,6 +18,23 @@ describe 'Moab::FileInstance' do
   let(:page1_v2_instance) do
     page1_v2_pathname = @fixtures.join('data/jq937jp0017/v0002/content/page-1.jpg')
     Moab::FileInstance.new.instance_from_file(page1_v2_pathname, v2_base_directory)
+  end
+
+  specify '#initialize' do
+    opts = {
+      path: @temp.join('path').to_s,
+      datetime: "Apr 18 21:51:31 UTC 2012"
+    }
+    file_instance = Moab::FileInstance.new(opts)
+    expect(file_instance.path).to eq opts[:path]
+    expect(file_instance.datetime).to eq "2012-04-18T21:51:31Z"
+  end
+
+  specify '#datetime reformats as ISO8601 (UTC Z format)' do
+    fi = Moab::FileInstance.new
+    value = "Wed Apr 18 21:51:31 UTC 2012"
+    fi.datetime = value
+    expect(fi.datetime).to eq "2012-04-18T21:51:31Z"
   end
 
   specify '#instance_from_file' do


### PR DESCRIPTION
Please review especially for:
- no useful tests removed  (some pointless ones have been removed)
- no existing test functionality has been changed (refactored some variable names or avoided long lines or changed otherwise for readability)

This spec cleanup:

- shortens names of specs to be just the method names
- removes comments containing the rdoc or implementation of methods
- removes specs that are useless  (e.g. that setting an attribute value means you can retrieve the attribute value;  that instantiating an object returns an instance of the object)
- splits out multiple tests in a single spec into separate tests
- avoids long lines
- refactors variable names for clarity
- removes unnecessary @ variables
- tried to follow principles to make rubocop happier
etc.
