### PR TITLE
unit_tests/moab/file_group_diff_subset_spec: remove cruft

### DIFF
--- a/spec/unit_tests/moab/file_group_difference_subset_spec.rb
+++ b/spec/unit_tests/moab/file_group_difference_subset_spec.rb
@@ -1,76 +1,56 @@
 require 'spec_helper'
 
-# Unit tests for class {Moab::FileGroupDifferenceSubset}
 describe 'Moab::FileGroupDifferenceSubset' do
 
-  describe '=========================== CONSTRUCTOR ===========================' do
-
-    # Unit test for constructor: {Moab::FileGroupDifferenceSubset#initialize}
-    # Which returns an instance of: [Moab::FileGroupDifferenceSubset]
-    # For input parameters:
-    # * opts [Hash<Symbol,Object>] = a hash containing any number of symbol => value pairs. The symbols should
-    #  correspond to attributes declared using HappyMapper syntax 
-    specify 'Moab::FileGroupDifferenceSubset#initialize' do
-
-      # test initialization with required parameters (if any)
-      opts = {}
-      file_group_difference_subset = Moab::FileGroupDifferenceSubset.new(opts)
-      expect(file_group_difference_subset).to be_instance_of(Moab::FileGroupDifferenceSubset)
-
-      # test initialization of arrays and hashes
-      expect(file_group_difference_subset.files).to be_kind_of(Array)
-      expect(file_group_difference_subset.files.size).to eq(0)
-
-      # test initialization with options hash
-      opts = Hash.new
-      opts[:change] = 'Test change'
-      file_group_difference_subset = Moab::FileGroupDifferenceSubset.new(opts)
-      expect(file_group_difference_subset.change).to eq(opts[:change])
-      expect(file_group_difference_subset.count).to eq(0)
-
-      # def initialize(opts={})
-      #   @files = Array.new
-      #   super(opts)
-      # end
+  describe '#initialize' do
+    specify 'empty options hash' do
+      diff_subset = Moab::FileGroupDifferenceSubset.new({})
+      expect(diff_subset.files).to be_kind_of Array
+      expect(diff_subset.files.size).to eq 0
     end
-  
+    specify 'options passed in' do
+      opts = { change: 'Test change' }
+      diff_subset = Moab::FileGroupDifferenceSubset.new(opts)
+      expect(diff_subset.change).to eq opts[:change]
+      expect(diff_subset.count).to eq 0
+    end
   end
-  
+
   describe '=========================== INSTANCE ATTRIBUTES ===========================' do
-    
+
     before(:all) do
       opts = {}
       @file_group_difference_subset = Moab::FileGroupDifferenceSubset.new(opts)
     end
-    
+
     # Unit test for attribute: {Moab::FileGroupDifferenceSubset#change}
     # Which stores: [String] The type of change (identical|renamed|modified|deleted|added)
     specify 'Moab::FileGroupDifferenceSubset#change' do
       value = 'Test change'
       @file_group_difference_subset.change= value
       expect(@file_group_difference_subset.change).to eq(value)
-       
+
       # attribute :change, String, :key => true
     end
-    
+
     # Unit test for attribute: {Moab::FileGroupDifferenceSubset#count}
     # Which stores: [Integer] How many files were changed
     specify 'Moab::FileGroupDifferenceSubset#count' do
       value = 52
       @file_group_difference_subset.count= value
       expect(@file_group_difference_subset.count).to eq(0)
-       
+
       # attribute :count, Integer, :on_save => Proc.new { |n| n.to_s }
     end
-    
+
     # Unit test for attribute: {Moab::FileGroupDifferenceSubset#files}
     # Which stores: [Array<Moab::FileInstanceDifference>] The set of file instances having this type of change
     specify 'Moab::FileGroupDifferenceSubset#files' do
       expect(@file_group_difference_subset.files.size).to eq(0)
-       
+
       # has_many :files, Moab::FileInstanceDifference
     end
-  
+
   end
 
 end

--- a/spec/unit_tests/moab/file_group_difference_subset_spec.rb
+++ b/spec/unit_tests/moab/file_group_difference_subset_spec.rb
@@ -16,41 +16,15 @@ describe 'Moab::FileGroupDifferenceSubset' do
     end
   end
 
-  describe '=========================== INSTANCE ATTRIBUTES ===========================' do
+  let(:diff_subset) { Moab::FileGroupDifferenceSubset.new }
 
-    before(:all) do
-      opts = {}
-      @file_group_difference_subset = Moab::FileGroupDifferenceSubset.new(opts)
-    end
-
-    # Unit test for attribute: {Moab::FileGroupDifferenceSubset#change}
-    # Which stores: [String] The type of change (identical|renamed|modified|deleted|added)
-    specify 'Moab::FileGroupDifferenceSubset#change' do
-      value = 'Test change'
-      @file_group_difference_subset.change= value
-      expect(@file_group_difference_subset.change).to eq(value)
-
-      # attribute :change, String, :key => true
-    end
-
-    # Unit test for attribute: {Moab::FileGroupDifferenceSubset#count}
-    # Which stores: [Integer] How many files were changed
-    specify 'Moab::FileGroupDifferenceSubset#count' do
-      value = 52
-      @file_group_difference_subset.count= value
-      expect(@file_group_difference_subset.count).to eq(0)
-
-      # attribute :count, Integer, :on_save => Proc.new { |n| n.to_s }
-    end
-
-    # Unit test for attribute: {Moab::FileGroupDifferenceSubset#files}
-    # Which stores: [Array<Moab::FileInstanceDifference>] The set of file instances having this type of change
-    specify 'Moab::FileGroupDifferenceSubset#files' do
-      expect(@file_group_difference_subset.files.size).to eq(0)
-
-      # has_many :files, Moab::FileInstanceDifference
-    end
-
+  specify '#count is computed, not set' do
+    value = 52
+    diff_subset.count = value
+    expect(diff_subset.count).to eq 0
   end
 
+  specify '#files is computed, not set' do
+    expect(diff_subset.files.size).to eq 0
+  end
 end

--- a/spec/unit_tests/moab/file_group_difference_subset_spec.rb
+++ b/spec/unit_tests/moab/file_group_difference_subset_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'Moab::FileGroupDifferenceSubset' do
+  let(:diff_subset) { Moab::FileGroupDifferenceSubset.new }
 
   describe '#initialize' do
     specify 'empty options hash' do
@@ -15,8 +16,6 @@ describe 'Moab::FileGroupDifferenceSubset' do
       expect(diff_subset.count).to eq 0
     end
   end
-
-  let(:diff_subset) { Moab::FileGroupDifferenceSubset.new }
 
   specify '#count is computed, not set' do
     value = 52


### PR DESCRIPTION
Please review especially for:
- no useful tests removed  (some pointless ones have been removed)
- no existing test functionality has been changed (refactored some variable names or avoided long lines or changed otherwise for readability)

This spec cleanup:

- shortens names of specs to be just the method names
- removes comments containing the rdoc or implementation of methods
- removes specs that are useless  (e.g. that setting an attribute value means you can retrieve the attribute value;  that instantiating an object returns an instance of the object)
- splits out multiple tests in a single spec into separate tests
- avoids long lines
- refactors variable names for clarity
- removes unnecessary @ variables
- tried to follow principles to make rubocop happier
etc.