### PR TITLE
code coverage no longer includes spec files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ rvm:
   - 2.2.4
   - 2.3.1
   - 2.4.1
+  - 2.4.2
+
+# script, expressed as an array, is necessary for 'bundle exec coveralls push' to work locally
+script:
+  - bundle exec rake
 
 cache: bundler
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,14 @@
 #$LOAD_PATH.unshift(File.dirname(__FILE__))
 #$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'coveralls'
-Coveralls.wear!
+Coveralls.wear_merged! # because we run travis on multiple rubies
 
-require 'rubygems'
-require 'rspec'
-require 'rspec/core'
+require 'simplecov'
+SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+SimpleCov.start do
+  add_filter 'spec'
+end
+
 require 'equivalent-xml'
 require 'moab/stanford'
 require 'spec_config'
@@ -13,14 +16,6 @@ require 'ap'
 
 RSpec.configure do |config|
   config.before(:all) {fixture_setup}
-  # Use Gherkin DSL syntax in specs for better readability
-  # scenario "<title>" do
-  #   given: <inputs>
-  #   action: <the application does>
-  #   outcome: <to generate this result>
-  #   ...
-  # end
-  config.alias_example_to :scenario
 end
 
 def fixtures_directory


### PR DESCRIPTION
- spec_helper:  
    - don't report coverage in spec files
    - only report coverage once per travis build (not for each ruby version)
    - cleaned up some cruft not needed or no longer needed
- .travis.yml:  added ruby 2.4.2;  added explicit script so we can run `bundle exec coverall push` if we want to check coverage for a build outside of travis

Note that coverage decrease is because we no longer count spec files.
