### PR TITLE
fix size computation methods, as Find.find is a recursive method

### DIFF
--- a/lib/moab/storage_object.rb
+++ b/lib/moab/storage_object.rb
@@ -231,7 +231,16 @@ module Moab
     def size
       size = 0
       Find.find(object_pathname) do |path|
-        size += FileTest.size(path) unless FileTest.directory?(path)
+        # note that Find.find is recursive so we want to have this explicit if.  See ruby Find class documentation
+        if FileTest.directory?(path)
+          if File.basename(path)[0] == '.' || File.basename(path)[0] == '..'
+            Find.prune # don't look any further into this directory
+          else
+            next
+          end
+        else
+          size += FileTest.size(path)
+        end
       end
       size
     end

--- a/lib/moab/storage_repository.rb
+++ b/lib/moab/storage_repository.rb
@@ -110,7 +110,16 @@ module Moab
       storage_pathname = find_storage_object(object_id, include_deposit).object_pathname
       size = 0
       Find.find(storage_pathname) do |path|
-        size += FileTest.size(path) unless FileTest.directory?(path)
+        # note that Find.find is recursive so we want to have this explicit if.  See ruby Find class documentation
+        if FileTest.directory?(path)
+          if File.basename(path)[0] == '.' || File.basename(path)[0] == '..'
+            Find.prune # don't look any further into this directory
+          else
+            next
+          end
+        else
+          size += FileTest.size(path)
+        end
       end
       size
     end


### PR DESCRIPTION
I think we may have been computing the incorrect size;  I made the code look exactly like the example here:  https://ruby-doc.org/stdlib-2.4.2/libdoc/find/rdoc/Find.html

Connects to #21 and #56