### PR TITLE
Use any version of RubyGems.

### DIFF
--- a/moab-versioning.gemspec
+++ b/moab-versioning.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.description = 'Contains classes to process digital object version content and metadata'
   s.homepage    = 'https://github.com/sul-dlss/moab-versioning'
 
-  s.required_rubygems_version = '>= 1.3.6'
   s.required_ruby_version = '~> 2.1'
 
   # Runtime dependencies


### PR DESCRIPTION
Fixes #39 

Version 1.3.6 of RubyGems is from February 2010. It seems that we can safely remove this version dependency.