### PR TITLE
Run identify_druid only if we know there is a moab with the correct dirs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,7 @@ Metrics/LineLength:
     - 'spec/unit_tests/moab/bagger_spec.rb' # remove after PR #52 merged
     - 'spec/unit_tests/moab/file_group_difference_spec.rb' # remove after PR #50 merged
     - 'spec/unit_tests/moab/storage_object_validator_spec.rb'
+    - 'spec/unit_tests/stanford/storage_object_validator_spec.rb'
 
 # Code was readable with allowing higher perceived complexity
 Metrics/PerceivedComplexity:

--- a/lib/stanford/storage_object_validator.rb
+++ b/lib/stanford/storage_object_validator.rb
@@ -11,7 +11,8 @@ module Stanford
     def validation_errors
       errors = []
       errors.concat super
-      errors.concat identify_druid
+      errors.concat(identify_druid) if errors.empty?
+      errors
     end
 
     def identify_druid

--- a/spec/unit_tests/stanford/storage_object_validator_spec.rb
+++ b/spec/unit_tests/stanford/storage_object_validator_spec.rb
@@ -10,7 +10,13 @@ RSpec.describe Stanford::StorageObjectValidator do
     it 'returns errors from calling the superclass validation_errors' do
       expect(verification_array.count).to eq(2)
     end
-
+    it 'returns validation error codes when there is file path for druid to directory validation' do
+      invalid_druid_path = 'spec/fixtures/bad_root01/bad_moab_storage_trunk/dd/000/dd/0000/dd000dd0000'
+      storage_obj = Moab::StorageObject.new('dd000dd0000', invalid_druid_path)
+      storage_obj_validator = described_class.new(storage_obj)
+      verification_array = storage_obj_validator.validation_errors
+      expect(verification_array).to include(Moab::StorageObjectValidator::VERSION_DIR_BAD_FORMAT => "Version directory name not in 'v00xx' format")
+    end
   end
 
   describe '#identify_druid' do


### PR DESCRIPTION
- Only run identify_druid if we know there is a manifest directory / correctly constructed Moab
- added correct test to spec/unit_tests/stanford