### PR TITLE
Use Regexp.match? when possible.

### DIFF
--- a/lib/moab/storage_object.rb
+++ b/lib/moab/storage_object.rb
@@ -133,7 +133,7 @@ module Moab
       return list unless @object_pathname.exist?
       @object_pathname.children.each do |dirname|
         vnum = dirname.basename.to_s
-        if vnum =~ /^v(\d+)$/
+        if vnum.match?(/^v(\d+)$/)
           list << vnum[1..-1].to_i
         end
       end

--- a/lib/moab/storage_object_validator.rb
+++ b/lib/moab/storage_object_validator.rb
@@ -64,7 +64,7 @@ module Moab
     def check_correctly_named_version_dirs
       errors = []
       version_directories.each do |version_dir|
-        errors << result_hash(VERSION_DIR_BAD_FORMAT) unless version_dir =~ /^[v]\d{4}$/
+        errors << result_hash(VERSION_DIR_BAD_FORMAT) unless version_dir.match?(/^[v]\d{4}$/)
       end
       errors
     end

--- a/lib/moab/storage_object_version.rb
+++ b/lib/moab/storage_object_version.rb
@@ -60,7 +60,7 @@ module Moab
   # @param [String] file_id The name of the file (path relative to base directory)
   # @return [FileSignature] signature of the specified file
     def find_signature(file_category, file_id)
-      if file_category =~ /manifest/
+      if file_category.match?(/manifest/)
         file_inventory('manifests').file_signature('manifests',file_id)
       else
         file_inventory('version').file_signature(file_category, file_id)
@@ -100,7 +100,7 @@ module Moab
   # @param [String] file_category The category of file ('content', 'metadata', or 's')
   # @return [Pathname] Pathname object containing this version's storage home for the specified file category
     def file_category_pathname(file_category)
-      if file_category =~ /manifest/
+      if file_category.match?(/manifest/)
         @version_pathname.join('manifests')
       else
         @version_pathname.join('data',file_category)

--- a/lib/moab/storage_services.rb
+++ b/lib/moab/storage_services.rb
@@ -89,7 +89,7 @@ module Moab
     # @return [FileInventory] the file inventory for the specified object version
     def self.retrieve_file_group(file_category, object_id, version_id=nil)
       storage_object_version = @@repository.storage_object(object_id).find_object_version(version_id)
-      if file_category =~ /manifest/
+      if file_category.match?(/manifest/)
         inventory_type = file_category = 'manifests'
       else
         inventory_type = 'version'


### PR DESCRIPTION
This is a performance enhancement:

https://blog.cognitohq.com/new-features-in-ruby-2-4/

The change introduced in this PR gets rid of a few RuboCop warnings that alerted me to this performance improvement.