### PR TITLE
File group diff spec five

### DIFF
--- a/spec/unit_tests/moab/file_group_difference_spec.rb
+++ b/spec/unit_tests/moab/file_group_difference_spec.rb
@@ -345,44 +345,23 @@ describe 'Moab::FileGroupDifference' do
   end
 
   specify '#tabulate_added_files' do
-    basis_group = v1_content
-    other_group = v3_content
-    signatures = new_diff.other_only_keys(basis_group.signature_hash, other_group.signature_hash)
-    expected_sig_fixity1 = {
-      size: "32915",
-      md5: "c1c34634e2f18a354cd3e3e1574c3194",
-      sha1: "0616a0bd7927328c364b2ea0b4a79c507ce915ed",
-      sha256: "b78cc53b7b8d9ed86d5e3bab3b699c7ed0db958d4a111e56b6936c8397137de0"
-    }
-    expected_sig_fixity2 = {
-      size: "39539",
-      md5: "fe6e3ffa1b02ced189db640f68da0cc2",
-      sha1: "43ced73681687bc8e6f483618f0dcff7665e0ba7",
-      sha256: "42c0cd1fe06615d8fdb8c2e3400d6fe38461310b4ecc252e1774e0c9e3981afa"
-    }
-    expect(signatures.collect { |s| s.fixity}).to eq [expected_sig_fixity1, expected_sig_fixity2]
-
-    basis_only_signatures = new_diff.basis_only_keys(basis_group.signature_hash, other_group.signature_hash)
-    other_only_signatures = new_diff.other_only_keys(basis_group.signature_hash, other_group.signature_hash)
-    basis_path_hash = basis_group.path_hash_subset(basis_only_signatures)
-    other_path_hash = other_group.path_hash_subset(other_only_signatures)
     new_diff.tabulate_added_files(basis_path_hash, other_path_hash)
     added_subset = new_diff.subset('added')
     expect(added_subset).to be_instance_of Moab::FileGroupDifferenceSubset
     expect(added_subset.change).to eq 'added'
     expect(added_subset.files.size).to eq 1
     expect(new_diff.added).to eq 1
-    file0 = added_subset.files[0]
-    expect(file0.change).to eq 'added'
-    expect(file0.basis_path).to eq ''
-    expect(file0.other_path).to eq 'page-2.jpg'
-    expected_sig_fixity = {
+    added_file = added_subset.files[0]
+    expect(added_file.change).to eq 'added'
+    expect(added_file.basis_path).to eq ''
+    expect(added_file.other_path).to eq 'page-2.jpg'
+    page_2_jpg_fixity = {
       size: "39539",
       md5: "fe6e3ffa1b02ced189db640f68da0cc2",
       sha1: "43ced73681687bc8e6f483618f0dcff7665e0ba7",
       sha256: "42c0cd1fe06615d8fdb8c2e3400d6fe38461310b4ecc252e1774e0c9e3981afa"
     }
-    expect(file0.signatures[0].fixity).to eq expected_sig_fixity
+    expect(added_file.signatures[0].fixity).to eq page_2_jpg_fixity
   end
 
   specify '.parse' do

--- a/spec/unit_tests/moab/file_group_difference_spec.rb
+++ b/spec/unit_tests/moab/file_group_difference_spec.rb
@@ -253,56 +253,34 @@ describe 'Moab::FileGroupDifference' do
   end
 
   specify '#tabulate_renamed_files' do
-    basis_group = v1_content
-    other_group = v3_content
-    signatures = new_diff.matching_keys(basis_group.signature_hash, other_group.signature_hash)
-    expected_sig_fixity1 = {
-      size: "39450",
-      md5: "82fc107c88446a3119a51a8663d1e955",
-      sha1: "d0857baa307a2e9efff42467b5abd4e1cf40fcd5",
-      sha256: "235de16df4804858aefb7690baf593fb572d64bb6875ec522a4eea1f4189b5f0"
-    }
-    expected_sig_fixity2 = {
-      size: "19125",
-      md5: "a5099878de7e2e064432d6df44ca8827",
-      sha1: "c0ccac433cf02a6cee89c14f9ba6072a184447a2",
-      sha256: "7bd120459eff0ecd21df94271e5c14771bfca5137d1dd74117b6a37123dfe271"
-    }
-    expected_sig_fixity3 = {
-      size: "40873",
-      md5: "1a726cd7963bd6d3ceb10a8c353ec166",
-      sha1: "583220e0572640abcd3ddd97393d224e8053a6ad",
-      sha256: "8b0cee693a3cf93cf85220dd67c5dc017a7edcdb59cde8fa7b7f697be162b0c5"
-    }
-    expect(signatures.collect { |s| s.fixity }).to eq [expected_sig_fixity1, expected_sig_fixity2, expected_sig_fixity3]
-    new_diff.tabulate_renamed_files(signatures, basis_group.signature_hash, other_group.signature_hash)
+    new_diff.tabulate_renamed_files(matching_keys_signatures, v1_content.signature_hash, v3_content.signature_hash)
     renamed_subset = new_diff.subset('renamed')
     expect(renamed_subset).to be_instance_of Moab::FileGroupDifferenceSubset
     expect(renamed_subset.change).to eq 'renamed'
     expect(renamed_subset.files.size).to eq 2
     expect(new_diff.renamed).to eq 2
-    file0 = renamed_subset.files[0]
-    expect(file0.change).to eq 'renamed'
-    expect(file0.basis_path).to eq 'page-2.jpg'
-    expect(file0.other_path).to eq 'page-3.jpg'
-    expected_sig_fixity = {
+    renamed_file_1 = renamed_subset.files[0]
+    expect(renamed_file_1.change).to eq 'renamed'
+    expect(renamed_file_1.basis_path).to eq 'page-2.jpg'
+    expect(renamed_file_1.other_path).to eq 'page-3.jpg'
+    page_2_jpg_fixity = {
       size: "39450",
       md5: "82fc107c88446a3119a51a8663d1e955",
       sha1: "d0857baa307a2e9efff42467b5abd4e1cf40fcd5",
       sha256: "235de16df4804858aefb7690baf593fb572d64bb6875ec522a4eea1f4189b5f0"
     }
-    expect(file0.signatures[0].fixity).to eq expected_sig_fixity
-    file1 = renamed_subset.files[1]
-    expect(file1.change).to eq 'renamed'
-    expect(file1.basis_path).to eq 'page-3.jpg'
-    expect(file1.other_path).to eq 'page-4.jpg'
-    expected_sig_fixity = {
+    expect(renamed_file_1.signatures[0].fixity).to eq page_2_jpg_fixity
+    renamed_file_2 = renamed_subset.files[1]
+    expect(renamed_file_2.change).to eq 'renamed'
+    expect(renamed_file_2.basis_path).to eq 'page-3.jpg'
+    expect(renamed_file_2.other_path).to eq 'page-4.jpg'
+    page_3_jpg_fixity = {
       size: "19125",
       md5: "a5099878de7e2e064432d6df44ca8827",
       sha1: "c0ccac433cf02a6cee89c14f9ba6072a184447a2",
       sha256: "7bd120459eff0ecd21df94271e5c14771bfca5137d1dd74117b6a37123dfe271"
     }
-    expect(file1.signatures[0].fixity).to eq expected_sig_fixity
+    expect(renamed_file_2.signatures[0].fixity).to eq page_3_jpg_fixity
   end
 
   specify '#tabulate_modified_files' do

--- a/spec/unit_tests/moab/file_group_difference_spec.rb
+++ b/spec/unit_tests/moab/file_group_difference_spec.rb
@@ -226,6 +226,8 @@ describe 'Moab::FileGroupDifference' do
     expect(new_diff.added).to eq 1
   end
 
+  # NOTE: tests below are ORDERED
+
   let(:matching_keys_signatures) do
     new_diff.matching_keys(v1_content.signature_hash, v3_content.signature_hash)
     # page-2.jpg, page-3.jpg, title.jpg

--- a/spec/unit_tests/moab/file_group_difference_spec.rb
+++ b/spec/unit_tests/moab/file_group_difference_spec.rb
@@ -414,7 +414,7 @@ describe 'Moab::FileGroupDifference' do
     expect(new_diff.rename_require_temp_files(renamed)).to eq false
   end
 
-  specify '#renames_require_temp_files' do
+  specify '#rename_tempfile_triplets' do
     renamed = [ [ "page-2.jpg", "page-3.jpg" ], [ "page-3.jpg", "page-4.jpg" ] ]
     triplets = new_diff.rename_tempfile_triplets(renamed)
     expect(triplets[0][0]).to eq "page-2.jpg"

--- a/spec/unit_tests/moab/file_group_difference_spec.rb
+++ b/spec/unit_tests/moab/file_group_difference_spec.rb
@@ -226,46 +226,30 @@ describe 'Moab::FileGroupDifference' do
     expect(new_diff.added).to eq 1
   end
 
+  let(:matching_keys_signatures) do
+    new_diff.matching_keys(v1_content.signature_hash, v3_content.signature_hash)
+    # page-2.jpg, page-3.jpg, title.jpg
+  end
+
   specify '#tabulate_unchanged_files' do
-    basis_group = v1_content
-    other_group = v3_content
-    signatures = new_diff.matching_keys(basis_group.signature_hash, other_group.signature_hash)
-    expected_sig_fixity1 = {
-      size: "39450",
-      md5: "82fc107c88446a3119a51a8663d1e955",
-      sha1: "d0857baa307a2e9efff42467b5abd4e1cf40fcd5",
-      sha256: "235de16df4804858aefb7690baf593fb572d64bb6875ec522a4eea1f4189b5f0"
-    }
-    expected_sig_fixity2 = {
-      size: "19125",
-      md5: "a5099878de7e2e064432d6df44ca8827",
-      sha1: "c0ccac433cf02a6cee89c14f9ba6072a184447a2",
-      sha256: "7bd120459eff0ecd21df94271e5c14771bfca5137d1dd74117b6a37123dfe271"
-    }
-    expected_sig_fixity3 = {
-      size: "40873",
-      md5: "1a726cd7963bd6d3ceb10a8c353ec166",
-      sha1: "583220e0572640abcd3ddd97393d224e8053a6ad",
-      sha256: "8b0cee693a3cf93cf85220dd67c5dc017a7edcdb59cde8fa7b7f697be162b0c5"
-    }
-    expect(signatures.collect { |s| s.fixity }).to eq [expected_sig_fixity1, expected_sig_fixity2, expected_sig_fixity3]
-    new_diff.tabulate_unchanged_files(signatures, basis_group.signature_hash, other_group.signature_hash)
+    new_diff.tabulate_unchanged_files(matching_keys_signatures, v1_content.signature_hash, v3_content.signature_hash)
+    expect(new_diff.subset_hash.keys).to eq [:identical]
     unchanged_subset = new_diff.subset('identical')
     expect(unchanged_subset).to be_instance_of Moab::FileGroupDifferenceSubset
     expect(unchanged_subset.change).to eq 'identical'
     expect(unchanged_subset.files.size).to eq 1
     expect(new_diff.identical).to eq 1
-    file0 = unchanged_subset.files[0]
-    expect(file0.change).to eq 'identical'
-    expect(file0.basis_path).to eq 'title.jpg'
-    expect(file0.other_path).to eq 'same'
-    expected_sig_fixity = {
+    unchanged_file = unchanged_subset.files[0]
+    expect(unchanged_file.change).to eq 'identical'
+    expect(unchanged_file.basis_path).to eq 'title.jpg'
+    expect(unchanged_file.other_path).to eq 'same'
+    title_jpg_fixity = {
       size: "40873",
       md5: "1a726cd7963bd6d3ceb10a8c353ec166",
       sha1: "583220e0572640abcd3ddd97393d224e8053a6ad",
       sha256: "8b0cee693a3cf93cf85220dd67c5dc017a7edcdb59cde8fa7b7f697be162b0c5"
     }
-    expect(file0.signatures[0].fixity).to eq expected_sig_fixity
+    expect(unchanged_file.signatures[0].fixity).to eq title_jpg_fixity
   end
 
   specify '#tabulate_renamed_files' do

--- a/spec/unit_tests/moab/file_group_difference_spec.rb
+++ b/spec/unit_tests/moab/file_group_difference_spec.rb
@@ -314,63 +314,34 @@ describe 'Moab::FileGroupDifference' do
   end
 
   specify '#tabulate_deleted_files' do
-    basis_group = v1_content
-    other_group = v3_content
-    expect((other_path_hash = other_group.path_hash).keys).to eq(
-      ["page-1.jpg", "page-2.jpg", "page-3.jpg", "page-4.jpg", "title.jpg"]
-    )
-    signatures = new_diff.basis_only_keys(basis_group.signature_hash, other_group.signature_hash)
-    expected_sig_fixity1 = {
-      size: "41981",
-      md5: "915c0305bf50c55143f1506295dc122c",
-      sha1: "60448956fbe069979fce6a6e55dba4ce1f915178",
-      sha256: "4943c6ffdea7e33b74fd7918de900de60e9073148302b0ad1bf5df0e6cec032a"
-    }
-    expected_sig_fixity2 = {
-      size: "39850",
-      md5: "77f1a4efdcea6a476505df9b9fba82a7",
-      sha1: "a49ae3f3771d99ceea13ec825c9c2b73fc1a9915",
-      sha256: "3a28718a8867e4329cd0363a84aee1c614d0f11229a82e87c6c5072a6e1b15e7"
-    }
-    expected_sig_fixity3 = {
-      size: "25153",
-      md5: "3dee12fb4f1c28351c7482b76ff76ae4",
-      sha1: "906c1314f3ab344563acbbbe2c7930f08429e35b",
-      sha256: "41aaf8598c9d8e3ee5d55efb9be11c542099d9f994b5935995d0abea231b8bad"
-    }
-    expect(signatures.collect { |s| s.fixity}).to eq [expected_sig_fixity1, expected_sig_fixity2, expected_sig_fixity3]
-    basis_only_signatures = new_diff.basis_only_keys(basis_group.signature_hash, other_group.signature_hash)
-    other_only_signatures = new_diff.other_only_keys(basis_group.signature_hash, other_group.signature_hash)
-    basis_path_hash = basis_group.path_hash_subset(basis_only_signatures)
-    other_path_hash = other_group.path_hash_subset(other_only_signatures)
     new_diff.tabulate_deleted_files(basis_path_hash, other_path_hash)
     deleted_subset = new_diff.subset('deleted')
     expect(deleted_subset).to be_instance_of Moab::FileGroupDifferenceSubset
     expect(deleted_subset.change).to eq 'deleted'
     expect(deleted_subset.files.size).to eq 2
     expect(new_diff.deleted).to eq 2
-    file0 = deleted_subset.files[0]
-    expect(file0.change).to eq 'deleted'
-    expect(file0.basis_path).to eq 'intro-1.jpg'
-    expect(file0.other_path).to eq ''
-    expected_sig_fixity = {
+    deleted_file_1 = deleted_subset.files[0]
+    expect(deleted_file_1.change).to eq 'deleted'
+    expect(deleted_file_1.basis_path).to eq 'intro-1.jpg'
+    expect(deleted_file_1.other_path).to eq ''
+    intro_1_jpg_fixity = {
       size: "41981",
       md5: "915c0305bf50c55143f1506295dc122c",
       sha1: "60448956fbe069979fce6a6e55dba4ce1f915178",
       sha256: "4943c6ffdea7e33b74fd7918de900de60e9073148302b0ad1bf5df0e6cec032a"
     }
-    expect(file0.signatures[0].fixity).to eq expected_sig_fixity
-    file1 = deleted_subset.files[1]
-    expect(file1.change).to eq 'deleted'
-    expect(file1.basis_path).to eq 'intro-2.jpg'
-    expect(file1.other_path).to eq ''
-    expected_sig_fixity = {
+    expect(deleted_file_1.signatures[0].fixity).to eq intro_1_jpg_fixity
+    deleted_file_2 = deleted_subset.files[1]
+    expect(deleted_file_2.change).to eq 'deleted'
+    expect(deleted_file_2.basis_path).to eq 'intro-2.jpg'
+    expect(deleted_file_2.other_path).to eq ''
+    intro_2_jpg_fixity = {
       size: "39850",
       md5: "77f1a4efdcea6a476505df9b9fba82a7",
       sha1: "a49ae3f3771d99ceea13ec825c9c2b73fc1a9915",
       sha256: "3a28718a8867e4329cd0363a84aee1c614d0f11229a82e87c6c5072a6e1b15e7"
     }
-    expect(file1.signatures[0].fixity).to eq expected_sig_fixity
+    expect(deleted_file_2.signatures[0].fixity).to eq intro_2_jpg_fixity
   end
 
   specify '#tabulate_added_files' do

--- a/spec/unit_tests/moab/file_group_difference_spec.rb
+++ b/spec/unit_tests/moab/file_group_difference_spec.rb
@@ -407,7 +407,7 @@ describe 'Moab::FileGroupDifference' do
     )
   end
 
-  specify '#renames_require_temp_files' do
+  specify '#rename_require_temp_files' do
     renamed = [ [ "page-2.jpg", "page-3.jpg" ], [ "page-3.jpg", "page-4.jpg" ] ]
     expect(new_diff.rename_require_temp_files(renamed)).to eq true
     renamed = [ [ "page-1.jpg", "page-1b.jpg" ], [ "page-2.jpg", "page-2b.jpg" ] ]

--- a/spec/unit_tests/moab/file_group_difference_spec.rb
+++ b/spec/unit_tests/moab/file_group_difference_spec.rb
@@ -283,53 +283,34 @@ describe 'Moab::FileGroupDifference' do
     expect(renamed_file_2.signatures[0].fixity).to eq page_3_jpg_fixity
   end
 
+  let(:basis_path_hash) do
+    basis_only_signatures = new_diff.basis_only_keys(v1_content.signature_hash, v3_content.signature_hash)
+    v1_content.path_hash_subset(basis_only_signatures)
+    # note: basis_path_hash.keys: intro-1.jpg, intro-2.jpg
+  end
+  let(:other_path_hash) do
+    other_only_signatures = new_diff.other_only_keys(v1_content.signature_hash, v3_content.signature_hash)
+    v3_content.path_hash_subset(other_only_signatures)
+    # note: other_path_hash.keys: page-1.jpg, page-2.jpg, page-3.jpg, page-4.jpg, title.jpg
+  end
   specify '#tabulate_modified_files' do
-    basis_group = v1_content
-    other_group = v3_content
-    expect((other_path_hash = other_group.path_hash).keys).to eq(
-      ["page-1.jpg", "page-2.jpg", "page-3.jpg", "page-4.jpg", "title.jpg"]
-    )
-    signatures = new_diff.basis_only_keys(basis_group.signature_hash, other_group.signature_hash)
-    expected_sig_fixity1 = {
-      size: "41981",
-      md5: "915c0305bf50c55143f1506295dc122c",
-      sha1: "60448956fbe069979fce6a6e55dba4ce1f915178",
-      sha256: "4943c6ffdea7e33b74fd7918de900de60e9073148302b0ad1bf5df0e6cec032a"
-    }
-    expected_sig_fixity2 = {
-      size: "39850",
-      md5: "77f1a4efdcea6a476505df9b9fba82a7",
-      sha1: "a49ae3f3771d99ceea13ec825c9c2b73fc1a9915",
-      sha256: "3a28718a8867e4329cd0363a84aee1c614d0f11229a82e87c6c5072a6e1b15e7"
-    }
-    expected_sig_fixity3 = {
-      size: "25153",
-      md5: "3dee12fb4f1c28351c7482b76ff76ae4",
-      sha1: "906c1314f3ab344563acbbbe2c7930f08429e35b",
-      sha256: "41aaf8598c9d8e3ee5d55efb9be11c542099d9f994b5935995d0abea231b8bad"
-    }
-    expect(signatures.collect { |s| s.fixity}).to eq [expected_sig_fixity1, expected_sig_fixity2, expected_sig_fixity3]
-    basis_only_signatures = new_diff.basis_only_keys(basis_group.signature_hash, other_group.signature_hash)
-    other_only_signatures = new_diff.other_only_keys(basis_group.signature_hash, other_group.signature_hash)
-    basis_path_hash = basis_group.path_hash_subset(basis_only_signatures)
-    other_path_hash = other_group.path_hash_subset(other_only_signatures)
     new_diff.tabulate_modified_files(basis_path_hash, other_path_hash)
     modified_subset = new_diff.subset('modified')
     expect(modified_subset).to be_instance_of Moab::FileGroupDifferenceSubset
     expect(modified_subset.change).to eq 'modified'
     expect(modified_subset.files.size).to eq 1
     expect(new_diff.modified).to eq 1
-    file0 = modified_subset.files[0]
-    expect(file0.change).to eq 'modified'
-    expect(file0.basis_path).to eq 'page-1.jpg'
-    expect(file0.other_path).to eq 'same'
-    expected_sig_fixity = {
+    modified_file = modified_subset.files[0]
+    expect(modified_file.change).to eq 'modified'
+    expect(modified_file.basis_path).to eq 'page-1.jpg'
+    expect(modified_file.other_path).to eq 'same'
+    page_1_jpg_fixity = {
       size: "25153",
       md5: "3dee12fb4f1c28351c7482b76ff76ae4",
       sha1: "906c1314f3ab344563acbbbe2c7930f08429e35b",
       sha256: "41aaf8598c9d8e3ee5d55efb9be11c542099d9f994b5935995d0abea231b8bad"
     }
-    expect(file0.signatures[0].fixity).to eq expected_sig_fixity
+    expect(modified_file.signatures[0].fixity).to eq page_1_jpg_fixity
   end
 
   specify '#tabulate_deleted_files' do

--- a/spec/unit_tests/moab/file_group_difference_spec.rb
+++ b/spec/unit_tests/moab/file_group_difference_spec.rb
@@ -261,28 +261,28 @@ describe 'Moab::FileGroupDifference' do
     expect(renamed_subset.change).to eq 'renamed'
     expect(renamed_subset.files.size).to eq 2
     expect(new_diff.renamed).to eq 2
-    renamed_file_1 = renamed_subset.files[0]
-    expect(renamed_file_1.change).to eq 'renamed'
-    expect(renamed_file_1.basis_path).to eq 'page-2.jpg'
-    expect(renamed_file_1.other_path).to eq 'page-3.jpg'
+    renamed_file1 = renamed_subset.files[0]
+    expect(renamed_file1.change).to eq 'renamed'
+    expect(renamed_file1.basis_path).to eq 'page-2.jpg'
+    expect(renamed_file1.other_path).to eq 'page-3.jpg'
     page_2_jpg_fixity = {
       size: "39450",
       md5: "82fc107c88446a3119a51a8663d1e955",
       sha1: "d0857baa307a2e9efff42467b5abd4e1cf40fcd5",
       sha256: "235de16df4804858aefb7690baf593fb572d64bb6875ec522a4eea1f4189b5f0"
     }
-    expect(renamed_file_1.signatures[0].fixity).to eq page_2_jpg_fixity
-    renamed_file_2 = renamed_subset.files[1]
-    expect(renamed_file_2.change).to eq 'renamed'
-    expect(renamed_file_2.basis_path).to eq 'page-3.jpg'
-    expect(renamed_file_2.other_path).to eq 'page-4.jpg'
+    expect(renamed_file1.signatures[0].fixity).to eq page_2_jpg_fixity
+    renamed_file2 = renamed_subset.files[1]
+    expect(renamed_file2.change).to eq 'renamed'
+    expect(renamed_file2.basis_path).to eq 'page-3.jpg'
+    expect(renamed_file2.other_path).to eq 'page-4.jpg'
     page_3_jpg_fixity = {
       size: "19125",
       md5: "a5099878de7e2e064432d6df44ca8827",
       sha1: "c0ccac433cf02a6cee89c14f9ba6072a184447a2",
       sha256: "7bd120459eff0ecd21df94271e5c14771bfca5137d1dd74117b6a37123dfe271"
     }
-    expect(renamed_file_2.signatures[0].fixity).to eq page_3_jpg_fixity
+    expect(renamed_file2.signatures[0].fixity).to eq page_3_jpg_fixity
   end
 
   let(:basis_path_hash) do
@@ -322,28 +322,28 @@ describe 'Moab::FileGroupDifference' do
     expect(deleted_subset.change).to eq 'deleted'
     expect(deleted_subset.files.size).to eq 2
     expect(new_diff.deleted).to eq 2
-    deleted_file_1 = deleted_subset.files[0]
-    expect(deleted_file_1.change).to eq 'deleted'
-    expect(deleted_file_1.basis_path).to eq 'intro-1.jpg'
-    expect(deleted_file_1.other_path).to eq ''
+    deleted_file1 = deleted_subset.files[0]
+    expect(deleted_file1.change).to eq 'deleted'
+    expect(deleted_file1.basis_path).to eq 'intro-1.jpg'
+    expect(deleted_file1.other_path).to eq ''
     intro_1_jpg_fixity = {
       size: "41981",
       md5: "915c0305bf50c55143f1506295dc122c",
       sha1: "60448956fbe069979fce6a6e55dba4ce1f915178",
       sha256: "4943c6ffdea7e33b74fd7918de900de60e9073148302b0ad1bf5df0e6cec032a"
     }
-    expect(deleted_file_1.signatures[0].fixity).to eq intro_1_jpg_fixity
-    deleted_file_2 = deleted_subset.files[1]
-    expect(deleted_file_2.change).to eq 'deleted'
-    expect(deleted_file_2.basis_path).to eq 'intro-2.jpg'
-    expect(deleted_file_2.other_path).to eq ''
+    expect(deleted_file1.signatures[0].fixity).to eq intro_1_jpg_fixity
+    deleted_file2 = deleted_subset.files[1]
+    expect(deleted_file2.change).to eq 'deleted'
+    expect(deleted_file2.basis_path).to eq 'intro-2.jpg'
+    expect(deleted_file2.other_path).to eq ''
     intro_2_jpg_fixity = {
       size: "39850",
       md5: "77f1a4efdcea6a476505df9b9fba82a7",
       sha1: "a49ae3f3771d99ceea13ec825c9c2b73fc1a9915",
       sha256: "3a28718a8867e4329cd0363a84aee1c614d0f11229a82e87c6c5072a6e1b15e7"
     }
-    expect(deleted_file_2.signatures[0].fixity).to eq intro_2_jpg_fixity
+    expect(deleted_file2.signatures[0].fixity).to eq intro_2_jpg_fixity
   end
 
   specify '#tabulate_added_files' do


### PR DESCRIPTION
update the #tabulate_xxx_files specs, fix 2 typos, and add a note that the specs are ordered.

Connects to #6