### PR TITLE
Reduce indirection

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -206,7 +206,6 @@ Style/AndOr:
     - 'lib/moab/file_signature.rb'
     - 'lib/moab/storage_object_version.rb'
     - 'lib/moab/storage_repository.rb'
-    - 'lib/moab/verification_result.rb'
     - 'lib/serializer/serializable.rb'
     - 'lib/stanford/content_inventory.rb'
 
@@ -279,7 +278,6 @@ Style/Documentation:
   Exclude:
     - 'spec/**/*'
     - 'test/**/*'
-    - 'lib/moab/verification_result.rb'
 
 # Offense count: 47
 # Cop supports --auto-correct.
@@ -386,7 +384,6 @@ Style/ParenthesesAroundCondition:
   Exclude:
     - 'lib/moab/file_manifestation.rb'
     - 'lib/moab/file_signature.rb'
-    - 'lib/moab/verification_result.rb'
     - 'spec/unit_tests/moab/verification_result_spec.rb'
 
 # Offense count: 8

--- a/lib/moab/storage_object_version.rb
+++ b/lib/moab/storage_object_version.rb
@@ -217,7 +217,7 @@ module Moab
       result
     end
 
-    # @return [Boolean] return true if the manifest inventory matches the actual files
+    # @return [VerificationResult] return true if the manifest inventory matches the actual files
     def verify_manifest_inventory
       # read/parse manifestInventory.xml
       result = VerificationResult.new("manifest_inventory")
@@ -240,6 +240,7 @@ module Moab
       result
     end
 
+    # @return [VerificationResult]
     def verify_signature_catalog
       result = VerificationResult.new("signature_catalog")
       signature_catalog = self.signature_catalog

--- a/lib/moab/verification_result.rb
+++ b/lib/moab/verification_result.rb
@@ -1,6 +1,7 @@
 require 'moab'
 
 module Moab
+  # A recursive "Tree" type object for verifications
   class VerificationResult
     # @return [String] The name of the entity that was verified
     attr_accessor :entity
@@ -15,34 +16,30 @@ module Moab
     attr_accessor :subentities
 
     # @param entity [Object] The name of the entity being verified
-    def initialize(entity)
+    # @param verified [Boolean]
+    # @param details [Hash]
+    def initialize(entity, verified = false, details = nil)
       @entity = entity
-      @verified = false
-      @details = nil
+      @verified = verified
+      @details = details
       @subentities = Array.new
     end
 
-    # @param entity [Symbol] The name of the entity being verified
+    # @param entity [#to_s] The name of the entity being verified
     # @param expected [Object] The expected value
     # @param found [Object] The found value
     # @return [VerificationResult] The result of comparing the expected and found values
     def self.verify_value(entity, expected, found)
-      result = VerificationResult.new(entity.to_s)
-      result.verified = (expected == found)
-      result.details = { 'expected' => expected, 'found' => found }
-      result
+      new(entity.to_s, (expected == found), 'expected' => expected, 'found' => found)
     end
 
-    # @param entity [Symbol] The name of the entity being verified
+    # @param entity [#to_s] The name of the entity being verified
     # @param expression [Object] The expression that will be evaluated as true or false
     # @param details [Object] optional details that could be reported
     # @return [VerificationResult] The result of evaluating the expression
     def self.verify_truth(entity, expression, details = nil)
-      result = VerificationResult.new(entity.to_s)
       # TODO: add expression.empty?
-      result.verified = !(expression.nil? or (expression == false))
-      result.details = details
-      result
+      new(entity.to_s, !(expression.nil? || (expression == false)), details)
     end
 
     # @param verbose [Boolean] If true, always provide all details of the verification
@@ -55,27 +52,21 @@ module Moab
     # @param level [Integer] Used to test the depth of recursion
     # @return [Hash] The verification result serialized to a hash
     def to_hash(verbose = false, level = 0)
-      hash = Hash.new
-      hash['verified'] = @verified
-      if (verbose or @verified == false)
-        hash['details'] = @details ? @details : subentities_to_hash(verbose, level)
+      hash = { 'verified' => verified }
+      if verbose || verified == false
+        hash['details'] = details || subentities_to_hash(verbose, level)
       end
-      if level > 0
-        hash
-      else
-        { @entity => hash }
-      end
+      return hash if level > 0
+      { entity => hash }
     end
+
+    private
 
     # @param verbose [Boolean] If true, always provide all details of the verification
     # @param level [Integer] Used to increment the depth of recursion
     # @return [Hash] The verification result of subentities serialized to a hash
     def subentities_to_hash(verbose, level)
-      hash = Hash.new
-      @subentities.each do |s|
-        hash[s.entity] = s.to_hash(verbose, level + 1)
-      end
-      hash
+      subentities.map { |s| [s.entity, s.to_hash(verbose, level + 1)] }.to_h
     end
   end
 end

--- a/lib/moab/verification_result.rb
+++ b/lib/moab/verification_result.rb
@@ -15,12 +15,12 @@ module Moab
     # @return [Array<VerificationResult>] The subentities, if any, on which this verification is based
     attr_accessor :subentities
 
-    # @param entity [Object] The name of the entity being verified
+    # @param entity [#to_s] The name of the entity being verified
     # @param verified [Boolean]
     # @param details [Hash]
     def initialize(entity, verified = false, details = nil)
-      @entity = entity
-      @verified = verified
+      @entity = entity.to_s  # force to string
+      @verified = !!verified # rubocop:disable Style/DoubleNegation
       @details = details
       @subentities = Array.new
     end
@@ -31,16 +31,16 @@ module Moab
     # @return [VerificationResult] The result of comparing the expected and found values
     def self.verify_value(entity, expected, found)
       details = { 'expected' => expected, 'found' => found }
-      new(entity.to_s, (expected == found), details)
+      new(entity, (expected == found), details)
     end
 
+    # @deprecated Just use the constructor
     # @param entity [#to_s] The name of the entity being verified
     # @param expression [Object] The expression that will be evaluated as true or false
     # @param details [Object] optional details that could be reported
     # @return [VerificationResult] The result of evaluating the expression
     def self.verify_truth(entity, expression, details = nil)
-      # TODO: add expression.empty?
-      new(entity.to_s, !(expression.nil? || (expression == false)), details)
+      new(entity, expression, details)
     end
 
     # @param verbose [Boolean] If true, always provide all details of the verification
@@ -54,7 +54,7 @@ module Moab
     # @return [Hash] The verification result serialized to a hash
     def to_hash(verbose = false, level = 0)
       hash = { 'verified' => verified }
-      if verbose || verified == false
+      if verbose || !verified
         hash['details'] = details || subentities_to_hash(verbose, level)
       end
       return hash if level > 0

--- a/lib/moab/verification_result.rb
+++ b/lib/moab/verification_result.rb
@@ -30,7 +30,8 @@ module Moab
     # @param found [Object] The found value
     # @return [VerificationResult] The result of comparing the expected and found values
     def self.verify_value(entity, expected, found)
-      new(entity.to_s, (expected == found), 'expected' => expected, 'found' => found)
+      details = { 'expected' => expected, 'found' => found }
+      new(entity.to_s, (expected == found), details)
     end
 
     # @param entity [#to_s] The name of the entity being verified


### PR DESCRIPTION
Subsume two single-line single-use methods.

Utilize guard clauses and the return value of `.concat` (and other methods).