### PR TITLE
Revert "Use Moab::Configure to set checkums active in FileSignature"

### DIFF
--- a/lib/moab/config.rb
+++ b/lib/moab/config.rb
@@ -7,6 +7,5 @@ module Moab
     storage_trunk nil
     deposit_trunk nil
     path_method :druid_tree
-    checksum_algos [:md5, :sha1, :sha256]
   end
 end

--- a/lib/moab/file_signature.rb
+++ b/lib/moab/file_signature.rb
@@ -66,15 +66,11 @@ module Moab
       sha256: proc { Digest::SHA2.new(256) }
     }.freeze
 
-    def self.active_algos
-      Moab::Config.checksum_algos
-    end
-
     # Reads the file once for ALL (requested) algorithms, not once per.
     # @param [Pathname] pathname
     # @param [Array<Symbol>] one or more keys of KNOWN_ALGOS to be computed
     # @return [Moab::FileSignature] object populated with (requested) checksums
-    def self.from_file(pathname, algos_to_use = active_algos)
+    def self.from_file(pathname, algos_to_use = KNOWN_ALGOS.keys)
       raise 'Unrecognized algorithm requested' unless algos_to_use.all? { |a| KNOWN_ALGOS.include?(a) }
 
       signatures = algos_to_use.map { |k| [k, KNOWN_ALGOS[k].call] }.to_h

--- a/spec/unit_tests/moab/file_signature_spec.rb
+++ b/spec/unit_tests/moab/file_signature_spec.rb
@@ -30,16 +30,6 @@ describe Moab::FileSignature do
       expect(sig.sha1).to eq '583220e0572640abcd3ddd97393d224e8053a6ad'
       expect(sig.sha256).to be_nil
     end
-
-    context 'when Moab::Config specifies checksums' do
-      before { allow(Moab::Config).to receive(:checksum_algos).and_return([:md5]) }
-      it 'only computes configured checksum(s)' do
-        sig = described_class.from_file(title_v1_pathname)
-        expect(sig.md5).to eq '1a726cd7963bd6d3ceb10a8c353ec166'
-        expect(sig.sha1).to be_nil
-        expect(sig.sha256).to be_nil
-      end
-    end
   end
 
   specify '#initialize' do


### PR DESCRIPTION
This reverts commit ed5c3a72bd860c10ff98be016c42b447123f1a28.