### PR TITLE
Don't require pry-byebug on CI

### DIFF
--- a/moab-versioning.gemspec
+++ b/moab-versioning.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'coveralls'
-  s.add_development_dependency 'pry-byebug'
+  s.add_development_dependency 'pry-byebug' unless ENV['CI']
   s.add_development_dependency 'rubocop', '~> 0.50.0' # avoid code churn due to rubocop changes
   s.add_development_dependency 'rubocop-rspec', '~> 1.18.0' # avoid code churn due to rubocop-rspec changes
 


### PR DESCRIPTION
Obviously we don't debug on Travis and this requirement actually breaks builds at install-time, like:
   https://travis-ci.org/sul-dlss/moab-versioning/jobs/364883575#L585

Error is: `byebug requires Ruby version >= 2.2.0`

Ideally we can eventually drop ruby 2.2 support, but this is a reasonable measure anyway.