### PR TITLE
Stop circular dependency loading

### DIFF
--- a/lib/moab/config.rb
+++ b/lib/moab/config.rb
@@ -1,5 +1,3 @@
-require 'moab'
-
 module Moab
   # @return [Confstruct::Configuration] the configuration data
   Config = Confstruct::Configuration.new do

--- a/lib/moab/file_group.rb
+++ b/lib/moab/file_group.rb
@@ -1,5 +1,3 @@
-require 'moab'
-
 module Moab
   # A container for a standard subset of a digital objects {FileManifestation} objects
   # Used to segregate depositor content from repository metadata files
@@ -24,6 +22,7 @@ module Moab
     def initialize(opts = {})
       @signature_hash = {}
       @data_source = ""
+      @signatures_from_bag = nil # prevents later warning: instance variable @signatures_from_bag not initialized
       super(opts)
     end
 

--- a/lib/moab/file_group_difference.rb
+++ b/lib/moab/file_group_difference.rb
@@ -1,5 +1,3 @@
-require 'moab'
-
 module Moab
   # Performs analysis and reports the differences between two matching {FileGroup} objects.
   # The descending elements of the report hold a detailed breakdown of file-level differences, organized by change type.

--- a/lib/moab/file_group_difference_subset.rb
+++ b/lib/moab/file_group_difference_subset.rb
@@ -1,5 +1,3 @@
-require 'moab'
-
 module Moab
   # A container for reporting a set of file-level differences of the type specified by the change attribute
   #

--- a/lib/moab/file_instance.rb
+++ b/lib/moab/file_instance.rb
@@ -1,5 +1,3 @@
-require 'moab'
-
 module Moab
   # The file path and last modification date properties of a file
   #

--- a/lib/moab/file_instance_difference.rb
+++ b/lib/moab/file_instance_difference.rb
@@ -1,5 +1,3 @@
-require 'moab'
-
 module Moab
   # A container for recording difference information at the file level
   # * If there was no change, the change type is set to <i>identical</i>

--- a/lib/moab/file_inventory.rb
+++ b/lib/moab/file_inventory.rb
@@ -1,5 +1,3 @@
-require 'moab'
-
 module Moab
   # A structured container for recording information about a collection of related files.
   #

--- a/lib/moab/file_inventory_difference.rb
+++ b/lib/moab/file_inventory_difference.rb
@@ -1,5 +1,3 @@
-require 'moab'
-
 module Moab
   # Compares two {FileInventory} instances based primarily on file signatures and secondarily on file pathnames.
   # Although the usual use will be to compare the content of 2 different temporal versions of the same object,

--- a/lib/moab/file_manifestation.rb
+++ b/lib/moab/file_manifestation.rb
@@ -1,5 +1,3 @@
-require 'moab'
-
 module Moab
   # A container for a file signature and all the physical file instances that have that signature
   # This element has one child {FileSignature} element, and one or more {FileInstance} elements

--- a/lib/moab/file_signature.rb
+++ b/lib/moab/file_signature.rb
@@ -1,5 +1,3 @@
-require 'moab'
-
 module Moab
   # The fixity properties of a file, used to determine file content equivalence regardless of filename.
   # Placing this data in a class by itself facilitates using file size together with the MD5 and SHA1 checksums

--- a/lib/moab/signature_catalog.rb
+++ b/lib/moab/signature_catalog.rb
@@ -1,5 +1,3 @@
-require 'moab'
-
 module Moab
   # A digital object's Signature Catalog is derived from an filtered aggregation of the file inventories
   # of a digital object's set of versions.  (see {#update})

--- a/lib/moab/signature_catalog_entry.rb
+++ b/lib/moab/signature_catalog_entry.rb
@@ -1,5 +1,3 @@
-require 'moab'
-
 module Moab
   # A file-level entry in a digital object's {SignatureCatalog}.
   # It has a child {FileSignature} element that identifies the file's contents (the bytestream)

--- a/lib/moab/storage_object.rb
+++ b/lib/moab/storage_object.rb
@@ -1,5 +1,3 @@
-require 'moab'
-
 module Moab
   # A class to represent a digital object's repository storage location
   # and methods for

--- a/lib/moab/storage_object_validator.rb
+++ b/lib/moab/storage_object_validator.rb
@@ -1,4 +1,3 @@
-require 'moab'
 require 'set'
 
 module Moab

--- a/lib/moab/storage_object_version.rb
+++ b/lib/moab/storage_object_version.rb
@@ -1,5 +1,3 @@
-require 'moab'
-
 module Moab
   # A class to represent a version subdirectory within an object's home directory in preservation storage
   # ====Data Model

--- a/lib/moab/storage_repository.rb
+++ b/lib/moab/storage_repository.rb
@@ -1,5 +1,3 @@
-require 'moab'
-
 module Moab
   # A class to represent the SDR repository store
   #

--- a/lib/moab/storage_services.rb
+++ b/lib/moab/storage_services.rb
@@ -1,5 +1,3 @@
-require 'moab'
-
 module Moab
   # An interface class to support access to SDR storage via a RESTful server
   #

--- a/lib/moab/utc_time.rb
+++ b/lib/moab/utc_time.rb
@@ -1,5 +1,3 @@
-require 'time'
-
 module Moab
   # Timestamp conversion methods.
   class UtcTime

--- a/lib/moab/verification_result.rb
+++ b/lib/moab/verification_result.rb
@@ -1,5 +1,3 @@
-require 'moab'
-
 module Moab
   # A recursive "Tree" type object for verifications
   class VerificationResult

--- a/lib/moab/version_metadata.rb
+++ b/lib/moab/version_metadata.rb
@@ -1,5 +1,3 @@
-require 'moab'
-
 module Moab
   # The descriptive information about a digital object's collection of versions
   #

--- a/lib/moab/version_metadata_entry.rb
+++ b/lib/moab/version_metadata_entry.rb
@@ -1,5 +1,3 @@
-require 'moab'
-
 module Moab
   # The descriptive attributes of a digital object version.
   #

--- a/lib/moab/version_metadata_event.rb
+++ b/lib/moab/version_metadata_event.rb
@@ -1,5 +1,3 @@
-require 'moab'
-
 module Moab
   # A container element to record object version lifecycle events with timestamps
   #

--- a/lib/stanford/active_fedora_object.rb
+++ b/lib/stanford/active_fedora_object.rb
@@ -1,5 +1,3 @@
-require 'moab/stanford'
-
 module Stanford
   # Utility Class for extracting content or other information from a Fedora Instance
   #

--- a/lib/stanford/content_inventory.rb
+++ b/lib/stanford/content_inventory.rb
@@ -1,5 +1,3 @@
-require 'moab/stanford'
-
 module Stanford
   # Stanford-specific utility methods for transforming contentMetadata to versionInventory and doing comparisons
   #

--- a/lib/stanford/dor_metadata.rb
+++ b/lib/stanford/dor_metadata.rb
@@ -1,5 +1,3 @@
-require 'moab/stanford'
-
 module Stanford
   # Stanford-specific utility methods for interfacing with DOR metadata files
   #

--- a/lib/stanford/storage_object_validator.rb
+++ b/lib/stanford/storage_object_validator.rb
@@ -1,5 +1,3 @@
-require 'moab'
-
 module Stanford
   # druids are Stanford specific entities
   class StorageObjectValidator < Moab::StorageObjectValidator

--- a/lib/stanford/storage_repository.rb
+++ b/lib/stanford/storage_repository.rb
@@ -1,4 +1,3 @@
-require 'moab/stanford'
 require 'druid-tools'
 
 module Stanford

--- a/lib/stanford/storage_services.rb
+++ b/lib/stanford/storage_services.rb
@@ -1,5 +1,3 @@
-require 'moab/stanford'
-
 module Stanford
   # An interface class to support access to SDR storage via a RESTful server
   class StorageServices < Moab::StorageServices


### PR DESCRIPTION
As revealed by `rspec --warnings`. This was an anti-pattern for a gem component to need to require the base namespace class because literally all consumers are already doing:
```
require 'moab'
```
or
```
require 'moab/stanford'
```

So the base class/namespace will always already be loaded before any subclass is invoked.