### PR TITLE
Include offending dir name to pertaining error codes

### DIFF
--- a/lib/moab/storage_object_validator.rb
+++ b/lib/moab/storage_object_validator.rb
@@ -58,11 +58,11 @@ module Moab
           NO_SIGNATURE_CATALOG => "Version %{addl}: Missing signatureCatalog.xml",
           NO_MANIFEST_INVENTORY => "Version %{addl}: Missing manifestInventory.xml",
           NO_FILES_IN_MANIFEST_DIR => "Version %{addl}: No files present in manifest dir",
-          METADATA_SUB_DIRS_DETECTED => "Version %{version}: metadata directory should only contain files, not directories: %{dir} directory",
+          METADATA_SUB_DIRS_DETECTED => "Version %{version}: metadata directory should only contain files, not directories. Found directory: %{dir}",
           VERSIONS_NOT_IN_ORDER => "Should contain only sequential version directories. Current directories: %{addl}",
           NO_FILES_IN_METADATA_DIR => "Version %{addl}: No files present in metadata dir",
           NO_FILES_IN_CONTENT_DIR => "Version %{addl}: No files present in content dir",
-          CONTENT_SUB_DIRS_DETECTED => "Version %{version}: content directory should only contain files, not directories: %{dir} directory",
+          CONTENT_SUB_DIRS_DETECTED => "Version %{version}: content directory should only contain files, not directories. Found directory: %{dir}",
           BAD_SUB_DIR_IN_CONTENT_DIR => "Version %{addl}: content directory has forbidden sub-directory name: vnnnn or #{FORBIDDEN_CONTENT_SUB_DIRS}"
         }.freeze
     end
@@ -205,6 +205,13 @@ module Moab
       path.split(File::SEPARATOR)[-1]
     end
 
+    # @param [Integer] response_code one of the recognized values in error_code_to_messages
+    # @param [Hash<Symbol => String>, String] msg_args Value(s) folded into the error message
+    # @return [Hash<Integer => String>] single key/value Hash
+    # @example Usage
+    #  sov.result_hash(10, '/some/dir')
+    #  sov.result_hash(10, addl: '/some/dir') # equivalent
+    #  sov.result_hash(8, version: '3', dir: '/other/dir')
     def result_hash(response_code, msg_args = nil)
       { response_code => error_code_msg(response_code, msg_args) }
     end

--- a/spec/unit_tests/moab/storage_object_validator_spec.rb
+++ b/spec/unit_tests/moab/storage_object_validator_spec.rb
@@ -105,14 +105,14 @@ describe Moab::StorageObjectValidator do
                 expect(storage_obj_validator.validation_errors(true)).to include(described_class::BAD_SUB_DIR_IN_CONTENT_DIR => "Version v0011: content directory has forbidden sub-directory name: vnnnn or [\"data\", \"manifests\", \"content\", \"metadata\"]")
               end
               it 'explicitly set to false and errors' do
-                expect(storage_obj_validator.validation_errors(false)).to include(described_class::CONTENT_SUB_DIRS_DETECTED => "Version v0015: content directory should only contain files, not directories")
+                expect(storage_obj_validator.validation_errors(false)).to include(described_class::CONTENT_SUB_DIRS_DETECTED => "Version v0015: content directory should only contain files, not directories: metadata directory")
               end
             end
           end
         end
         context 'metadata directory' do
           it 'must only contain files' do
-            expect(error_list).to include(described_class::METADATA_SUB_DIRS_DETECTED => "Version v0008: metadata directory should only contain files, not directories")
+            expect(error_list).to include(described_class::METADATA_SUB_DIRS_DETECTED => "Version v0008: metadata directory should only contain files, not directories: test1 directory")
           end
           it 'must contain files' do
             expect(error_list).to include(described_class::NO_FILES_IN_METADATA_DIR => "Version v0010: No files present in metadata dir")

--- a/spec/unit_tests/moab/storage_object_validator_spec.rb
+++ b/spec/unit_tests/moab/storage_object_validator_spec.rb
@@ -105,14 +105,14 @@ describe Moab::StorageObjectValidator do
                 expect(storage_obj_validator.validation_errors(true)).to include(described_class::BAD_SUB_DIR_IN_CONTENT_DIR => "Version v0011: content directory has forbidden sub-directory name: vnnnn or [\"data\", \"manifests\", \"content\", \"metadata\"]")
               end
               it 'explicitly set to false and errors' do
-                expect(storage_obj_validator.validation_errors(false)).to include(described_class::CONTENT_SUB_DIRS_DETECTED => "Version v0015: content directory should only contain files, not directories: metadata directory")
+                expect(storage_obj_validator.validation_errors(false)).to include(described_class::CONTENT_SUB_DIRS_DETECTED => "Version v0015: content directory should only contain files, not directories. Found directory: metadata")
               end
             end
           end
         end
         context 'metadata directory' do
           it 'must only contain files' do
-            expect(error_list).to include(described_class::METADATA_SUB_DIRS_DETECTED => "Version v0008: metadata directory should only contain files, not directories: test1 directory")
+            expect(error_list).to include(described_class::METADATA_SUB_DIRS_DETECTED => "Version v0008: metadata directory should only contain files, not directories. Found directory: test1")
           end
           it 'must contain files' do
             expect(error_list).to include(described_class::NO_FILES_IN_METADATA_DIR => "Version v0010: No files present in metadata dir")

--- a/spec/unit_tests/stanford/storage_object_validator_spec.rb
+++ b/spec/unit_tests/stanford/storage_object_validator_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Stanford::StorageObjectValidator do
     end
     context 'allow_content_subdirs arguments' do
       it 'passes to super' do
-        expect(storage_obj_validator.validation_errors(false)).to include(Moab::StorageObjectValidator::CONTENT_SUB_DIRS_DETECTED => 'Version v0013: content directory should only contain files, not directories')
+        expect(storage_obj_validator.validation_errors(false)).to include(Moab::StorageObjectValidator::CONTENT_SUB_DIRS_DETECTED => 'Version v0013: content directory should only contain files, not directories: data directory')
       end
     end
   end

--- a/spec/unit_tests/stanford/storage_object_validator_spec.rb
+++ b/spec/unit_tests/stanford/storage_object_validator_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe Stanford::StorageObjectValidator do
     end
     context 'allow_content_subdirs arguments' do
       it 'passes to super' do
-        expect(storage_obj_validator.validation_errors(false)).to include(Moab::StorageObjectValidator::CONTENT_SUB_DIRS_DETECTED => 'Version v0013: content directory should only contain files, not directories: data directory')
+        expect(storage_obj_validator.validation_errors(false))
+          .to include(Moab::StorageObjectValidator::CONTENT_SUB_DIRS_DETECTED => 'Version v0013: content directory should only contain files, not directories. Found directory: data')
       end
     end
   end


### PR DESCRIPTION
An example log output from seeding
```
[2017-11-22T04:55:11.113017 #25241] ERROR -- :  .............. 
Invalid moab, validation errors: ["Should only contain files, but directories were present in the content directory"]
```

So this PR will give us more details on which directory was present and is not supposed to be there.


 - allow `error_code_msg` to take multiple args other than `addl`
- `METADATA_SUB_DIRS_DETECTED` and `CONTENT_SUB_DIRS_DETECTED`changed `addl` to `version` and added a `dir` variable to tell us the offending directory in logs.

closes #106 