### PR TITLE
add InvalidSuriSyntaxError, MoabRuntimeError, MoabStandardError

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+## Why was this change made?
+
+
+
+## Was the usage documentation (e.g. wiki, README) updated?

--- a/lib/moab/bagger.rb
+++ b/lib/moab/bagger.rb
@@ -259,7 +259,7 @@ module Moab
       rescue
         shell_execute(tar_cmd.sub('--force-local', ''))
       end
-      raise "Unable to create tarfile #{tar_pathname}" unless tar_pathname.exist?
+      raise(MoabRuntimeError, "Unable to create tarfile #{tar_pathname}") unless tar_pathname.exist?
       true
     end
 
@@ -274,11 +274,11 @@ module Moab
       else
         msg = "Shell command failed: [#{command}] caused by <STDERR = #{stderr}>"
         msg << " STDOUT = #{stdout}" if stdout && stdout.length.positive?
-        raise(StandardError, msg)
+        raise(MoabStandardError, msg)
       end
     rescue SystemCallError => e
       msg = "Shell command failed: [#{command}] caused by #{e.inspect}"
-      raise(StandardError, msg)
+      raise(MoabStandardError, msg)
     end
   end
 end

--- a/lib/moab/exceptions.rb
+++ b/lib/moab/exceptions.rb
@@ -1,13 +1,9 @@
 module Moab
-  class ObjectNotFoundException < RuntimeError
-  end
+  class MoabRuntimeError < RuntimeError; end
+  class MoabStandardError < StandardError; end
 
-  class FileNotFoundException < RuntimeError
-  end
-
-  class InvalidMetadataException < RuntimeError
-  end
-
-  class ValidationException < RuntimeError
-  end
+  class FileNotFoundException < MoabRuntimeError; end
+  class InvalidMetadataException < MoabRuntimeError; end
+  class InvalidSuriSyntaxError < MoabRuntimeError; end
+  class ObjectNotFoundException < MoabRuntimeError; end
 end

--- a/lib/moab/file_group.rb
+++ b/lib/moab/file_group.rb
@@ -160,10 +160,10 @@ module Moab
     # @param pathname [Pathname] The file path to be tested
     # @return [Boolean] Test whether the given path is contained within the {#base_directory}
     def is_descendent_of_base?(pathname)
-      raise("base_directory has not been set") if @base_directory.nil?
+      raise(MoabRuntimeError, "base_directory has not been set") if @base_directory.nil?
       is_descendent = false
       pathname.expand_path.ascend { |ancestor| is_descendent ||= (ancestor == @base_directory) }
-      raise("#{pathname} is not a descendent of #{@base_directory}") unless is_descendent
+      raise(MoabRuntimeError, "#{pathname} is not a descendent of #{@base_directory}") unless is_descendent
       is_descendent
     end
 

--- a/lib/moab/file_signature.rb
+++ b/lib/moab/file_signature.rb
@@ -73,7 +73,7 @@ module Moab
     # @param [Array<Symbol>] one or more keys of KNOWN_ALGOS to be computed
     # @return [Moab::FileSignature] object populated with (requested) checksums
     def self.from_file(pathname, algos_to_use = active_algos)
-      raise 'Unrecognized algorithm requested' unless algos_to_use.all? { |a| KNOWN_ALGOS.include?(a) }
+      raise(MoabRuntimeError, 'Unrecognized algorithm requested') unless algos_to_use.all? { |a| KNOWN_ALGOS.include?(a) }
 
       signatures = algos_to_use.map { |k| [k, KNOWN_ALGOS[k].call] }.to_h
 
@@ -178,7 +178,7 @@ module Moab
       return sig_from_file if eql?(sig_from_file)
       # The full signature from file is consistent with current values, or...
       # One or more of the fixity values is inconsistent, so raise an exception
-      raise "Signature inconsistent between inventory and file for #{pathname}: #{diff(sig_from_file).inspect}"
+      raise(MoabRuntimeError, "Signature inconsistent between inventory and file for #{pathname}: #{diff(sig_from_file).inspect}")
     end
 
     # @return [Hash<Symbol,String>] Key is type (e.g. :sha1), value is checksum names (e.g. ['SHA-1', 'SHA1'])

--- a/lib/moab/signature_catalog.rb
+++ b/lib/moab/signature_catalog.rb
@@ -128,7 +128,7 @@ module Moab
     def normalize_group_signatures(group, group_pathname = nil)
       unless group_pathname.nil?
         group_pathname = Pathname(group_pathname)
-        raise "Could not locate #{group_pathname}" unless group_pathname.exist?
+        raise(MoabRuntimeError, "Could not locate #{group_pathname}") unless group_pathname.exist?
       end
       group.files.each do |file|
         unless file.signature.complete?

--- a/lib/moab/storage_object.rb
+++ b/lib/moab/storage_object.rb
@@ -161,7 +161,7 @@ module Moab
     # @return [Boolean] Tests whether the new version number is one higher than the current version number
     def validate_new_inventory(version_inventory)
       if version_inventory.version_id != (current_version_id + 1)
-        raise "version mismatch - current: #{current_version_id} new: #{version_inventory.version_id}"
+        raise(MoabRuntimeError, "version mismatch - current: #{current_version_id} new: #{version_inventory.version_id}")
       end
       true
     end
@@ -177,7 +177,7 @@ module Moab
       when 1..current
         StorageObjectVersion.new(self, version_id)
       else
-        raise "Version ID #{version_id} does not exist"
+        raise(MoabRuntimeError, "Version ID #{version_id} does not exist")
       end
     end
 
@@ -187,7 +187,7 @@ module Moab
     # * Version 0 is a special case used to generate empty manifests
     # * Current version + 1 is used for creation of a new version
     def storage_object_version(version_id)
-      raise "Version ID not specified" unless version_id
+      raise(MoabRuntimeError, "Version ID not specified") unless version_id
       StorageObjectVersion.new(self, version_id)
     end
 

--- a/lib/moab/storage_object_version.rb
+++ b/lib/moab/storage_object_version.rb
@@ -33,7 +33,7 @@ module Moab
       elsif version_id.is_a?(String) && version_id =~ /^v(\d+)$/
         @version_id = version_id.sub(/^v/, '').to_i
       else
-        raise "version_id (#{version_id}) is not in a recognized format"
+        raise(MoabRuntimeError, "version_id (#{version_id}) is not in a recognized format")
       end
       @version_name = StorageObject.version_dirname(@version_id)
       @version_pathname = storage_object.object_pathname.join(@version_name)
@@ -135,7 +135,7 @@ module Moab
     # @param bag_dir [Pathname,String] The location of the bag to be ingested
     # @return [void] Create the version subdirectory and move files into it
     def ingest_bag_data(bag_dir)
-      raise "Version already exists: #{@version_pathname}" if @version_pathname.exist?
+      raise(MoabRuntimeError, "Version already exists: #{@version_pathname}") if @version_pathname.exist?
       @version_pathname.join('manifests').mkpath
       bag_dir = Pathname(bag_dir)
       ingest_dir(bag_dir.join('data'), @version_pathname.join('data'))
@@ -149,7 +149,7 @@ module Moab
     # @param use_links [Boolean] If true, use hard links; if false, make copies
     # @return [void] recursively link or copy the source directory contents to the target directory
     def ingest_dir(source_dir, target_dir, use_links = true)
-      raise "cannot copy - target already exists: #{target_dir.expand_path}" if target_dir.exist?
+      raise(MoabRuntimeError, "cannot copy - target already exists: #{target_dir.expand_path}") if target_dir.exist?
       target_dir.mkpath
       source_dir.children.each do |child|
         if child.directory?

--- a/lib/moab/storage_repository.rb
+++ b/lib/moab/storage_repository.rb
@@ -18,10 +18,10 @@ module Moab
     # @return [Array<Pathname>] The list of filesystem root paths in which objects are stored
     def storage_roots
       unless defined?(@storage_roots)
-        raise "Moab::Config.storage_roots not found in config file" if Moab::Config.storage_roots.nil?
+        raise(MoabRuntimeError, "Moab::Config.storage_roots not found in config file") if Moab::Config.storage_roots.nil?
         @storage_roots = [Moab::Config.storage_roots].flatten.collect { |filesystem| Pathname(filesystem) }
-        raise "Moab::Config.storage_roots empty" if @storage_roots.empty?
-        @storage_roots.each { |root| raise "Storage root #{root} not found on system" unless root.exist? }
+        raise(MoabRuntimeError, "Moab::Config.storage_roots empty") if @storage_roots.empty?
+        @storage_roots.each { |root| raise(MoabRuntimeError, "Storage root #{root} not found on system") unless root.exist? }
       end
       @storage_roots
     end
@@ -29,7 +29,7 @@ module Moab
     # @return [String] The trunk segment of the object storage path
     def storage_trunk
       unless defined?(@storage_trunk)
-        raise "Moab::Config.storage_trunk not found in config file" if Moab::Config.storage_trunk.nil?
+        raise(MoabRuntimeError, "Moab::Config.storage_trunk not found in config file") if Moab::Config.storage_trunk.nil?
         @storage_trunk  = Moab::Config.storage_trunk
       end
       @storage_trunk
@@ -70,7 +70,7 @@ module Moab
       branch = storage_branch(object_id)
       storage_roots.each do |root|
         root_trunk = root.join(storage_trunk)
-        raise "Storage area not found at #{root_trunk}" unless root_trunk.exist?
+        raise(MoabRuntimeError, "Storage area not found at #{root_trunk}") unless root_trunk.exist?
         root_trunk_branch = root_trunk.join(branch)
         return root if root_trunk_branch.exist?
       end
@@ -79,7 +79,7 @@ module Moab
         branch = deposit_branch(object_id)
         storage_roots.each do |root|
           root_trunk = root.join(deposit_trunk)
-          raise "Deposit area not found at #{root_trunk}" unless root_trunk.exist?
+          raise(MoabRuntimeError, "Deposit area not found at #{root_trunk}") unless root_trunk.exist?
           root_trunk_branch = root_trunk.join(branch)
           return root if root_trunk_branch.exist?
         end
@@ -117,7 +117,7 @@ module Moab
     def storage_object(object_id, create = false)
       storage_object = find_storage_object(object_id)
       unless storage_object.object_pathname.exist?
-        raise Moab::ObjectNotFoundException, "No storage object found for #{object_id}" unless create
+        raise ObjectNotFoundException, "No storage object found for #{object_id}" unless create
         storage_object.object_pathname.mkpath
       end
       storage_object

--- a/lib/moab/utc_time.rb
+++ b/lib/moab/utc_time.rb
@@ -14,7 +14,7 @@ module Moab
       when Time
         datetime
       else
-        raise "unknown time format #{datetime.inspect}"
+        raise(MoabRuntimeError, "unknown time format #{datetime.inspect}")
       end
     end
 
@@ -29,7 +29,7 @@ module Moab
       when Time
         datetime.utc.iso8601
       else
-        raise "unknown time format #{datetime.inspect}"
+        raise(MoabRuntimeError, "unknown time format #{datetime.inspect}")
       end
     end
   end

--- a/lib/serializer/serializable.rb
+++ b/lib/serializer/serializable.rb
@@ -19,7 +19,8 @@ module Serializer
     #   The symbols should correspond to attributes declared using HappyMapper syntax
     def initialize(opts = {})
       opts.each do |key, value|
-        raise "#{key} is not a variable name in #{self.class.name}" unless variable_names.include?(key.to_s) || key == :test
+        errmsg = "#{key} is not a variable name in #{self.class.name}"
+        raise(Moab::MoabRuntimeError, errmsg) unless variable_names.include?(key.to_s) || key == :test
         instance_variable_set("@#{key}", value)
       end
     end
@@ -115,7 +116,7 @@ module Serializer
     # @param other [Serializable] The other object being compared
     # @return [Hash] Generate a hash containing the differences between two objects of the same type
     def diff(other)
-      raise "Cannot compare different classes" if self.class != other.class
+      raise(Moab::MoabRuntimeError, "Cannot compare different classes") if self.class != other.class
       left = other.to_hash
       right = to_hash
       if key.nil? || other.key.nil?

--- a/lib/stanford/content_inventory.rb
+++ b/lib/stanford/content_inventory.rb
@@ -45,7 +45,7 @@ module Stanford
                 when 'all'
                   ng_doc.xpath("//file")
                 else
-                  raise "Unknown disposition subset (#{subset})"
+                  raise(Moab::MoabRuntimeError, "Unknown disposition subset (#{subset})")
                 end
       content_group = Moab::FileGroup.new(:group_id => 'content', :data_source => "contentMetadata-#{subset}")
       nodeset.each do |file_node|
@@ -198,7 +198,7 @@ module Stanford
       if file_size.nil? || file_size.empty?
         file_node['size'] = signature.size.to_s
       elsif file_size != signature.size.to_s
-        raise "Inconsistent size for #{file_node['id']}: #{file_size} != #{signature.size}"
+        raise(Moab::MoabRuntimeError, "Inconsistent size for #{file_node['id']}: #{file_size} != #{signature.size}")
       end
     end
 
@@ -228,7 +228,7 @@ module Stanford
         if cm_checksum.nil? || cm_checksum.empty?
           checksum_node.content = sig_checksum
         elsif cm_checksum != sig_checksum
-          raise "Inconsistent #{type} for #{file_node['id']}: #{cm_checksum} != #{sig_checksum}"
+          raise(Moab::MoabRuntimeError, "Inconsistent #{type} for #{file_node['id']}: #{cm_checksum} != #{sig_checksum}")
         end
       end
     end

--- a/lib/stanford/storage_repository.rb
+++ b/lib/stanford/storage_repository.rb
@@ -31,10 +31,10 @@ module Stanford
     def druid_tree(object_id)
       # Note: this seems an odd place to do druid validation, but leaving it here for now
       syntax_msg = "Identifier has invalid suri syntax: #{object_id}"
-      raise syntax_msg + " nil or empty" if object_id.to_s.empty?
+      raise(Moab::InvalidSuriSyntaxError, syntax_msg + " nil or empty") if object_id.to_s.empty?
       identifier = object_id.split(':')[-1]
-      raise syntax_msg if identifier.to_s.empty?
-      raise syntax_msg unless DruidTools::Druid.valid?(identifier, true)
+      raise(Moab::InvalidSuriSyntaxError, syntax_msg) if identifier.to_s.empty?
+      raise(Moab::InvalidSuriSyntaxError, syntax_msg) unless DruidTools::Druid.valid?(identifier, true)
       DruidTools::Druid.new(identifier, true).tree.join(File::SEPARATOR)
     end
   end

--- a/spec/unit_tests/moab/bagger_spec.rb
+++ b/spec/unit_tests/moab/bagger_spec.rb
@@ -298,6 +298,6 @@ describe Moab::Bagger do
     bagger = described_class.new(nil, nil, bag_dir)
     cmd = "cd '#{@packages}'; tar --dereference --force-local -cf  '#{@temp}/test.tar' 'v0001'"
     expect(bagger).to receive(:shell_execute).with(cmd)
-    expect { bagger.create_tarfile(tarfile) }.to raise_exception(/Unable to create tarfile/)
+    expect { bagger.create_tarfile(tarfile) }.to raise_exception(Moab::MoabRuntimeError, /^Unable to create tarfile/)
   end
 end

--- a/spec/unit_tests/moab/file_group_spec.rb
+++ b/spec/unit_tests/moab/file_group_spec.rb
@@ -93,7 +93,8 @@ describe Moab::FileGroup do
       it "raises exception if false (FIXME!)" do
         base = @fixtures.join('derivatives/manifests')
         # FIXME:  shouldn't it simply return false?
-        expect { @new_file_group.is_descendent_of_base?(base) }.to raise_exception(/is not a descendent of/)
+        exp_msg_regex = /is not a descendent of/
+        expect { @new_file_group.is_descendent_of_base?(base) }.to raise_exception(Moab::MoabRuntimeError, exp_msg_regex)
       end
     end
 

--- a/spec/unit_tests/moab/file_signature_spec.rb
+++ b/spec/unit_tests/moab/file_signature_spec.rb
@@ -16,7 +16,8 @@ describe Moab::FileSignature do
 
   describe '.from_file' do
     it 'raises if unrecognized checksum requested' do
-      expect { described_class.from_file('whatever', [:rot13]) }.to raise_exception(/Unrecognized algorithm/)
+      exp_msg_regex = /Unrecognized algorithm/
+      expect { described_class.from_file('whatever', [:rot13]) }.to raise_exception(Moab::MoabRuntimeError, exp_msg_regex)
     end
     it 'computes all checksums by default' do
       sig = described_class.from_file(title_v1_pathname)
@@ -137,7 +138,7 @@ describe Moab::FileSignature do
     specify 'when given bad checksum' do
       fs = described_class.new(sha1: 'dummy')
       exp_err_regex = /Signature inconsistent between inventory and file/
-      expect { fs.normalized_signature(page2_v1_pathname) }.to raise_exception(exp_err_regex)
+      expect { fs.normalized_signature(page2_v1_pathname) }.to raise_exception(Moab::MoabRuntimeError, exp_err_regex)
     end
   end
 

--- a/spec/unit_tests/moab/storage_object_spec.rb
+++ b/spec/unit_tests/moab/storage_object_spec.rb
@@ -390,7 +390,8 @@ describe Moab::StorageObject do
   specify '#validate_new_inventory' do
     version_inventory_3 = double(Moab::FileInventory.name + "3")
     expect(version_inventory_3).to receive(:version_id).twice.and_return 3
-    expect { storage_object.validate_new_inventory(version_inventory_3) }.to raise_exception(/version mismatch/)
+    exp_regex = /version mismatch/
+    expect { storage_object.validate_new_inventory(version_inventory_3) }.to raise_exception(Moab::MoabRuntimeError, exp_regex)
 
     version_inventory_4 = double(Moab::FileInventory.name + "4")
     expect(version_inventory_4).to receive(:version_id).and_return 4
@@ -414,8 +415,8 @@ describe Moab::StorageObject do
       expect(version_latest.version_pathname.to_s).to match(/ingests\/jq937jp0017\/v0003/)
     end
     it 'non-existent versions' do
-      expect { @storage_object.find_object_version(0) }.to raise_exception(/Version ID 0 does not exist/)
-      expect { @storage_object.find_object_version(4) }.to raise_exception(/Version ID 4 does not exist/)
+      expect { @storage_object.find_object_version(0) }.to raise_exception(Moab::MoabRuntimeError, /Version ID 0 does not exist/)
+      expect { @storage_object.find_object_version(4) }.to raise_exception(Moab::MoabRuntimeError, /Version ID 4 does not exist/)
     end
   end
 
@@ -433,7 +434,8 @@ describe Moab::StorageObject do
       expect { @storage_object.storage_object_version(4) }.not_to raise_exception
     end
     it 'nil version raises exception' do
-      expect { @storage_object.storage_object_version(nil) }.to raise_exception(/Version ID not specified/)
+      exp_msg_regex = /Version ID not specified/
+      expect { @storage_object.storage_object_version(nil) }.to raise_exception(Moab::MoabRuntimeError, exp_msg_regex)
     end
   end
 

--- a/spec/unit_tests/moab/storage_repository_spec.rb
+++ b/spec/unit_tests/moab/storage_repository_spec.rb
@@ -35,7 +35,7 @@ describe Moab::StorageRepository do
     end
     it 'exception raised when storage_trunk is bogus' do
       allow(storage_repo).to receive(:storage_trunk).and_return('junk')
-      expect { storage_repo.find_storage_root('abcdef') }.to raise_exception(/Storage area not found/)
+      expect { storage_repo.find_storage_root('abcdef') }.to raise_exception(Moab::MoabRuntimeError, /Storage area not found/)
     end
   end
 

--- a/spec/unit_tests/moab/utc_time_spec.rb
+++ b/spec/unit_tests/moab/utc_time_spec.rb
@@ -13,8 +13,8 @@ describe Moab::UtcTime do
     it 'bad string data raises ArgumentError' do
       expect { described_class.input("jgkerf") }.to raise_exception ArgumentError
     end
-    it 'bad non-string data raises RuntimeError of "unknown time format"' do
-      expect { described_class.input(4) }.to raise_exception(RuntimeError, 'unknown time format 4')
+    it 'bad non-string data raises MoabRuntimeError of "unknown time format"' do
+      expect { described_class.input(4) }.to raise_exception(Moab::MoabRuntimeError, 'unknown time format 4')
     end
   end
 
@@ -30,8 +30,8 @@ describe Moab::UtcTime do
     it 'bad string data raises ArgumentError' do
       expect { described_class.output("jgkerf") }.to raise_exception ArgumentError
     end
-    it 'bad non-string data raises RuntimeError of "unknown time format"' do
-      expect { described_class.output(4) }.to raise_exception(RuntimeError, 'unknown time format 4')
+    it 'bad non-string data raises MoabRuntimeError of "unknown time format"' do
+      expect { described_class.output(4) }.to raise_exception(Moab::MoabRuntimeError, 'unknown time format 4')
     end
   end
 end

--- a/spec/unit_tests/serializer/serializable_spec.rb
+++ b/spec/unit_tests/serializer/serializable_spec.rb
@@ -67,7 +67,7 @@ describe Serializer::Serializable do
     it 'options hash with bad variable raises exception' do
       opts = { dummy: 'dummy' }
       err_msg = 'dummy is not a variable name in Serializer::Serializable'
-      expect { described_class.new(opts) }.to raise_exception(RuntimeError, err_msg)
+      expect { described_class.new(opts) }.to raise_exception(Moab::MoabRuntimeError, err_msg)
     end
   end
 

--- a/spec/unit_tests/stanford/content_inventory_spec.rb
+++ b/spec/unit_tests/stanford/content_inventory_spec.rb
@@ -133,7 +133,7 @@ describe Stanford::ContentInventory do
     end
     it 'raises exception for unknown subset' do
       exp_regex = /Unknown disposition subset/
-      expect { described_class.new.group_from_cm(cm_with_subsets, "dummy") }.to raise_exception(exp_regex)
+      expect { described_class.new.group_from_cm(cm_with_subsets, "dummy") }.to raise_exception(Moab::MoabRuntimeError, exp_regex)
     end
   end
 
@@ -227,7 +227,9 @@ describe Stanford::ContentInventory do
     end
     it 'empty hash raises exception' do
       exp_regex = /Content Metadata is in unrecognized format/
-      expect { @content_inventory.validate_content_metadata_details({}) }.to raise_exception(exp_regex)
+      expect do
+        @content_inventory.validate_content_metadata_details({})
+      end.to raise_exception(Moab::InvalidMetadataException, exp_regex)
     end
   end
 
@@ -278,13 +280,17 @@ describe Stanford::ContentInventory do
     it 'bad size raises exception' do
       cm_bad_size = cm.sub(/40873/, '37804')
       exp_regex = /Inconsistent size for title.jpg: 37804 != 40873/
-      expect { @content_inventory.remediate_content_metadata(cm_bad_size, group) }.to raise_exception(exp_regex)
+      expect do
+        @content_inventory.remediate_content_metadata(cm_bad_size, group)
+      end.to raise_exception(Moab::MoabRuntimeError, exp_regex)
     end
 
     it 'bad checksum raises exception' do
       cm_bad_checksum = cm.sub(/1a726cd7963bd6d3ceb10a8c353ec166/, '915c0305bf50c55143f1506295dc122c')
       exp_regex = /Inconsistent md5 for title.jpg: 915c0305bf50c55143f1506295dc122c != 1a726cd7963bd6d3ceb10a8c353ec166/
-      expect { @content_inventory.remediate_content_metadata(cm_bad_checksum, group) }.to raise_exception(exp_regex)
+      expect do
+        @content_inventory.remediate_content_metadata(cm_bad_checksum, group)
+      end.to raise_exception(Moab::MoabRuntimeError, exp_regex)
     end
   end
 end

--- a/spec/unit_tests/stanford/storage_repository_spec.rb
+++ b/spec/unit_tests/stanford/storage_repository_spec.rb
@@ -20,13 +20,13 @@ describe Stanford::StorageRepository do
     it 'has expected value for valid druid' do
       expect(storage_repository.druid_tree(@druid)).to eq("jq/937/jp/0017/jq937jp0017")
     end
-    it 'raises exception for invalid druid' do
-      exp_msg_regex = /Identifier has invalid suri syntax/
-      expect { storage_repository.druid_tree('123cd456nm') }.to raise_exception(RuntimeError, exp_msg_regex)
+    it 'raises InvalidSuriSyntaxError for invalid druid' do
+      exp_msg_regex = /Identifier has invalid suri syntax: 123cd456nm/
+      expect { storage_repository.druid_tree('123cd456nm') }.to raise_exception(Moab::InvalidSuriSyntaxError, exp_msg_regex)
     end
-    it 'has expected value for valid druid that uses forbidden chars (not strictly valid)' do
-      exp_msg_regex = /^Identifier has invalid suri syntax: druid:aa111bb2222$/
-      expect { storage_repository.druid_tree('druid:aa111bb2222') }.to raise_exception(RuntimeError, exp_msg_regex)
+    it 'raises InvalidSuriSyntaxError for druid that uses forbidden chars (not strictly valid)' do
+      exp_regex = /^Identifier has invalid suri syntax: druid:aa111bb2222$/
+      expect { storage_repository.druid_tree('druid:aa111bb2222') }.to raise_exception(Moab::InvalidSuriSyntaxError, exp_regex)
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Closes #159

To fix a kludge in preservation_catalog (see https://github.com/sul-dlss/preservation_catalog/pull/1207/files) that would become more onerous as prescat gets more API functionality to replace sdr-services-app.

## Was the usage documentation (e.g. wiki, README) updated?

N/A