### PR TITLE
Drop dependency on confstruct

### DIFF
--- a/lib/moab.rb
+++ b/lib/moab.rb
@@ -35,7 +35,6 @@ module Moab
 end
 
 require 'serializer'
-require 'confstruct/configuration'
 require 'moab/config'
 require 'moab/utc_time'
 require 'moab/file_signature'

--- a/lib/moab/config.rb
+++ b/lib/moab/config.rb
@@ -1,12 +1,43 @@
 # frozen_string_literal: true
 
 module Moab
-  # @return [Confstruct::Configuration] the configuration data
-  Config = Confstruct::Configuration.new do
-    storage_roots nil
-    storage_trunk nil
-    deposit_trunk nil
-    path_method :druid_tree
-    checksum_algos [:md5, :sha1, :sha256]
+  # A place to store configuration for the gem
+  class Configuration
+    def initialize
+      @path_method = :druid_tree
+      @checksum_algos = [:md5, :sha1, :sha256]
+    end
+
+    def configure(&block)
+      instance_eval(&block)
+    end
+
+    def storage_roots(new_value = nil)
+      @storage_roots = new_value if new_value
+      @storage_roots
+    end
+
+    def storage_trunk(new_value = nil)
+      @storage_trunk = new_value if new_value
+      @storage_trunk
+    end
+
+    def deposit_trunk(new_value = nil)
+      @deposit_trunk = new_value if new_value
+      @deposit_trunk
+    end
+
+    def path_method(new_value = nil)
+      @path_method = new_value if new_value
+      @path_method
+    end
+
+    def checksum_algos(new_value = nil)
+      @checksum_algos = new_value if new_value
+      @checksum_algos
+    end
   end
+
+  # @return [Moab::Configuration] the configuration data
+  Config = Configuration.new
 end

--- a/moab-versioning.gemspec
+++ b/moab-versioning.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '~> 2.3'
 
   # Runtime dependencies
-  s.add_dependency 'confstruct'
   s.add_dependency 'druid-tools', '>= 1.0.0 ' # druid validation, druid-tree, etc.; needs 1.0.0 for strict validation
   s.add_dependency 'json'
   s.add_dependency 'nokogiri' # XML parsing


### PR DESCRIPTION


## Why was this change made?

It's easy enough to maintain our own static config.  The confstruct gem is no longer maintained.

## Was the usage documentation (e.g. wiki, README) updated?
n/a