### PR TITLE
Update Readme.md to expand examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,5 +250,3 @@ depending on whether XML serialization is required.
 
 * **Stanford::DorMetadata** = utility methods for interfacing with Stanford metadata files (esp contentMetadata)
   * **Stanford::ActiveFedoraObject** [1..*] = utility for extracting content or other information from a Fedora Instance
-
-

--- a/README.md
+++ b/README.md
@@ -214,8 +214,6 @@ moab.version_list.each do |ver|
 end
 ```
 
-
-
 ## API Documentation
 
 http://rubydoc.info/github/sul-dlss/moab-versioning/main/frames

--- a/README.md
+++ b/README.md
@@ -189,9 +189,6 @@ end
 druid = "druid:#{ARGV[0]}"
 # druid = 'cq580gn5234'
 
-storage_repository = Stanford::StorageRepository.new()
-storage_object = storage_repository.find_storage_object(druid)
-
 path = Moab::StorageServices.object_path(druid)
 puts "#{druid} found at #{path}"
 


### PR DESCRIPTION
This includes a known-good script that will completely validate a given Druid in Stanford's environment.

## Why was this change made?

The existing example in Readme.md doesn't fully illustrate how to check a Moab in Stanford's environment.

## How was this change tested?

Checked against both known-good and broken druids.

## Which documentation and/or configurations were updated?

Readme.md


