### PR TITLE
[MAJOR] Remove unused method version_metadata

### DIFF
--- a/lib/moab/storage_services.rb
+++ b/lib/moab/storage_services.rb
@@ -84,12 +84,6 @@ module Moab
     end
 
     # @param [String] object_id The digital object identifier of the object
-    # @return [Pathname] Pathname object containing the full path for the specified file
-    def self.version_metadata(object_id)
-      retrieve_file('metadata', 'versionMetadata.xml', object_id)
-    end
-
-    # @param [String] object_id The digital object identifier of the object
     # @param [Integer] version_id The ID of the version, if nil use latest version
     # @return [FileInventory] the file inventory for the specified object version
     def self.retrieve_file_group(file_category, object_id, version_id = nil)

--- a/spec/unit_tests/moab/storage_services_spec.rb
+++ b/spec/unit_tests/moab/storage_services_spec.rb
@@ -69,26 +69,6 @@ describe Moab::StorageServices do
     expect(described_class.object_size(@obj)).to be_between(340000, 350000)
   end
 
-  specify '.version_metadata' do
-    vm_ng_xml = Nokogiri::XML(described_class.version_metadata(@obj).read)
-    exp_xml = <<-XML
-      <versionMetadata objectId="druid:jq937jp0017">
-        <version versionId="1" label="1.0" significance="major">
-          <description>Initial version</description>
-        </version>
-        <version versionId="2" label="2.0" significance="minor">
-          <description>Editing page-1 and removing intro files</description>
-          <note>content change</note>
-        </version>
-        <version versionId="3" label="2.1" significance="minor">
-          <description>Inserting new page-2, with renames of pages 2-3 to 3-4</description>
-          <note>page insertion</note>
-        </version>
-      </versionMetadata>
-    XML
-    expect(EquivalentXml.equivalent?(vm_ng_xml, Nokogiri::XML(exp_xml), eq_xml_opts)).to be true
-  end
-
   describe '.retrieve_file_group' do
     it 'content' do
       group = described_class.retrieve_file_group('content', @obj, 2)


### PR DESCRIPTION


## Why was this change made?
This was tightly coupled to Fedora 3 and is not used anywhere.


## How was this change tested?



## Which documentation and/or configurations were updated?



