### PR TITLE
[Hold] Fix SimpleCov startup to support Ruby 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: ruby
 
 rvm:
-  - 2.3.1
-  - 2.4.2
-  - 2.5.3
+  - 2.7.5
+  - 3.1.1
 
 # script, expressed as an array, is necessary for 'bundle exec coveralls push' to work locally
 script:

--- a/moab-versioning.gemspec
+++ b/moab-versioning.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = 'Contains classes to process digital object version content and metadata'
   s.homepage    = 'https://github.com/sul-dlss/moab-versioning'
 
-  s.required_ruby_version = '>= 3.1'
+  s.required_ruby_version = '>= 2.7'
 
   # Runtime dependencies
   s.add_dependency 'druid-tools', '>= 1.0.0 ' # druid validation, druid-tree, etc.; needs 1.0.0 for strict validation

--- a/moab-versioning.gemspec
+++ b/moab-versioning.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = 'Contains classes to process digital object version content and metadata'
   s.homepage    = 'https://github.com/sul-dlss/moab-versioning'
 
-  s.required_ruby_version = '>= 2.7'
+  s.required_ruby_version = '>= 3.1'
 
   # Runtime dependencies
   s.add_dependency 'druid-tools', '>= 1.0.0 ' # druid validation, druid-tree, etc.; needs 1.0.0 for strict validation

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,9 +5,9 @@ Coveralls.wear_merged! # because we run travis on multiple rubies
 
 require 'simplecov'
 SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-SimpleCov.start do
-  add_filter 'spec'
-end
+SimpleCov.add_filter 'spec'
+
+SimpleCov.start 'rails' unless SimpleCov.running
 
 require 'equivalent-xml'
 require 'moab/stanford'


### PR DESCRIPTION
## Why was this change made? 🤔

There is an issue in SimpleCov for ruby >= 3.x with duplicate startup (https://github.com/simplecov-ruby/simplecov/issues/1003). This guards against the duplicate start.

Follow up work will/should include cleaning up deprecations and new cops before pushing a new gem version.

## How was this change tested? 🤨

Manually against ruby 2.7.5 and 3.1.1

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to filesystem, or what is expected to be read from filesystem), run ***[integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** on stage as it tests preservation, and/or test in stage environment, in addition to specs.⚡


