### PR TITLE
Fix minor issue/difference between circle tests and local

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,6 +60,10 @@ Style/ZeroLengthPredicate:
   Exclude:
     - 'lib/moab/bagger.rb' # is calling `x.size == 0` on Pathname objects, which don't have `.empty?` on old Rubies
 
+RSpec/ExampleLength:
+  Exclude:
+    - 'spec/**/*' # Spec exampels may have many lines of test data, ignore ExmapleLength for tests.
+
 Gemspec/DateAssignment: # new in 1.10
   Enabled: true
 Gemspec/RequireMFA: # new in 1.23

--- a/spec/unit_tests/moab/storage_object_spec.rb
+++ b/spec/unit_tests/moab/storage_object_spec.rb
@@ -152,7 +152,10 @@ describe Moab::StorageObject do
 
     new_inventory_ng_xml = Nokogiri::XML(new_inventory.to_xml)
     new_inventory_ng_xml.xpath('//@datetime').each { |d| d.value = '' }
-    new_inventory_ng_xml.xpath('//@dataSource').each { |d| d.value = d.value.gsub('/home/circleci/project', 'moab-versioning') }
+    new_inventory_ng_xml.xpath('//@dataSource').each do |d|
+      d.value = d.value.gsub(/.*moab-versioning/, 'moab-versioning')
+      d.value = d.value.gsub('/home/circleci/project', 'moab-versioning')
+    end
     new_inventory_ng_xml.xpath('//@inventoryDatetime').remove
     exp_xml = <<-XML
       <fileInventory type="version" objectId="druid:jq937jp0017" versionId="1"  fileCount="11" byteCount="217820" blockCount="216">


### PR DESCRIPTION
## Why was this change made? 🤔

There is a small difference between the data output on circle and locally, so this line is required to allow the tests to pass locally and in circle (line 156).

This highlights a smell that should be addressed as part of #194 


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to filesystem, or what is expected to be read from filesystem), run ***[integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** on stage as it tests preservation, and/or test in stage environment, in addition to specs.⚡


