### PR TITLE
Enable new cops and autocorrect

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -172,3 +172,30 @@ RSpec/FactoryBot/SyntaxMethods: # new in 2.7
   Enabled: true
 RSpec/Rails/AvoidSetupHook: # new in 2.4
   Enabled: true
+
+Gemspec/DeprecatedAttributeAssignment: # new in 1.30
+  Enabled: true
+Lint/RefinementImportMethods: # new in 1.27
+  Enabled: true
+Security/CompoundHash: # new in 1.28
+  Enabled: true
+Style/EnvHome: # new in 1.29
+  Enabled: true
+Style/FetchEnvVar: # new in 1.28
+  Enabled: true
+Style/MapCompactWithConditionalBlock: # new in 1.30
+  Enabled: true
+Style/NestedFileDirname: # new in 1.26
+  Enabled: true
+Style/ObjectThen: # new in 1.28
+  Enabled: true
+Style/RedundantInitialize: # new in 1.27
+  Enabled: true
+RSpec/BeEq: # new in 2.9.0
+  Enabled: true
+RSpec/BeNil: # new in 2.9.0
+  Enabled: true
+RSpec/ChangeByZero: # new in 2.11.0
+  Enabled: true
+RSpec/VerifiedDoubleReference: # new in 2.10.0
+  Enabled: true

--- a/spec/unit_tests/moab/bagger_spec.rb
+++ b/spec/unit_tests/moab/bagger_spec.rb
@@ -54,21 +54,21 @@ describe Moab::Bagger do
     bag_dir = packages.join('deleteme')
     data_dir = bag_dir.join('data')
     data_dir.mkpath
-    expect(data_dir.exist?).to eq true
+    expect(data_dir.exist?).to be true
     bagger = described_class.new(nil, nil, bag_dir)
     bagger.delete_bag
-    expect(bag_dir.exist?).to eq false
+    expect(bag_dir.exist?).to be false
   end
 
   specify '#delete_tarfile' do
     packages = @temp.join('packages')
     tar_file = packages.join('deleteme.tar')
     tar_file.open('w') { |f| f.puts "delete me please" }
-    expect(tar_file.exist?).to eq true
+    expect(tar_file.exist?).to be true
     bag_dir = packages.join('deleteme')
     bagger = described_class.new(nil, nil, bag_dir)
     bagger.delete_tarfile
-    expect(tar_file.exist?).to eq false
+    expect(tar_file.exist?).to be false
   end
 
   describe '#fill_bag' do
@@ -228,7 +228,7 @@ describe Moab::Bagger do
     submit_bag.fill_payload(submit_source_base)
     submit_bag.create_payload_manifests
     md5 = submit_bag.bag_pathname.join('manifest-md5.txt')
-    expect(md5.exist?).to eq true
+    expect(md5.exist?).to be true
     expect(md5.readlines.sort).to eq [
       "351e4c872148e0bc9dc24874c7ef6c08 data/metadata/provenanceMetadata.xml\n",
       "8672613ac1757cda4e44cc464559cd04 data/metadata/contentMetadata.xml\n",
@@ -236,7 +236,7 @@ describe Moab::Bagger do
       "c1c34634e2f18a354cd3e3e1574c3194 data/content/page-1.jpg\n"
     ]
     sha1 = submit_bag.bag_pathname.join('manifest-sha1.txt')
-    expect(sha1.exist?).to eq true
+    expect(sha1.exist?).to be true
     expect(sha1.readlines.sort).to eq [
       "0616a0bd7927328c364b2ea0b4a79c507ce915ed data/content/page-1.jpg\n",
       "565473bbc865b1c6f88efc99b6b5b73fd5cadbc8 data/metadata/provenanceMetadata.xml\n",
@@ -248,7 +248,7 @@ describe Moab::Bagger do
   specify '#create_bag_info_txt' do
     submit_bag.create_bag_info_txt
     bag_info = submit_bag.bag_pathname.join('bag-info.txt')
-    expect(bag_info.exist?).to eq true
+    expect(bag_info.exist?).to be true
     expect(bag_info.readlines).to eq [
       "External-Identifier: druid:jq937jp0017-v2\n",
       "Payload-Oxum: 35181.4\n",
@@ -259,7 +259,7 @@ describe Moab::Bagger do
   specify '#create_bagit_txt' do
     submit_bag.create_bagit_txt
     bagit = submit_bag.bag_pathname.join('bagit.txt')
-    expect(bagit.exist?).to eq true
+    expect(bagit.exist?).to be true
     expect(bagit.readlines).to eq [
       "Tag-File-Character-Encoding: UTF-8\n",
       "BagIt-Version: 0.97\n"
@@ -270,7 +270,7 @@ describe Moab::Bagger do
     expect(submit_bag).to receive(:create_tagfile_manifests).and_call_original
     submit_bag.fill_bag(:depositor, submit_source_base)
     md5 = submit_bag.bag_pathname.join('tagmanifest-md5.txt')
-    expect(md5.exist?).to eq true
+    expect(md5.exist?).to be true
     expect(md5.readlines.collect { |line| line.split(/ /)[1] }).to match_array [
       "bag-info.txt\n",
       "bagit.txt\n",
@@ -282,7 +282,7 @@ describe Moab::Bagger do
     ]
 
     sha1 = submit_bag.bag_pathname.join('tagmanifest-sha1.txt')
-    expect(sha1.exist?).to eq true
+    expect(sha1.exist?).to be true
     expect(sha1.readlines.collect { |line| line.split(/ /)[1] }).to match_array [
       "bag-info.txt\n",
       "bagit.txt\n",

--- a/spec/unit_tests/moab/file_group_difference_spec.rb
+++ b/spec/unit_tests/moab/file_group_difference_spec.rb
@@ -420,9 +420,9 @@ describe Moab::FileGroupDifference do
 
   specify '#rename_require_temp_files' do
     renamed = [["page-2.jpg", "page-3.jpg"], ["page-3.jpg", "page-4.jpg"]]
-    expect(new_diff.rename_require_temp_files(renamed)).to eq true
+    expect(new_diff.rename_require_temp_files(renamed)).to be true
     renamed = [["page-1.jpg", "page-1b.jpg"], ["page-2.jpg", "page-2b.jpg"]]
-    expect(new_diff.rename_require_temp_files(renamed)).to eq false
+    expect(new_diff.rename_require_temp_files(renamed)).to be false
   end
 
   specify '#rename_tempfile_triplets' do

--- a/spec/unit_tests/moab/file_instance_spec.rb
+++ b/spec/unit_tests/moab/file_instance_spec.rb
@@ -42,20 +42,20 @@ describe Moab::FileInstance do
   end
 
   specify '#eql?' do
-    expect(title_v1_instance.eql?(title_v2_instance)).to eq true
-    expect(page1_v1_instance.eql?(page1_v2_instance)).to eq true
-    expect(title_v1_instance.eql?(page1_v2_instance)).to eq false
+    expect(title_v1_instance.eql?(title_v2_instance)).to be true
+    expect(page1_v1_instance.eql?(page1_v2_instance)).to be true
+    expect(title_v1_instance.eql?(page1_v2_instance)).to be false
   end
 
   specify '#==' do
-    expect(title_v1_instance == title_v2_instance).to eq true
-    expect(page1_v1_instance == page1_v2_instance).to eq true
-    expect(title_v1_instance == page1_v2_instance).to eq false
+    expect(title_v1_instance == title_v2_instance).to be true
+    expect(page1_v1_instance == page1_v2_instance).to be true
+    expect(title_v1_instance == page1_v2_instance).to be false
   end
 
   specify '#hash' do
-    expect(title_v1_instance.hash == title_v2_instance.hash).to eq true
-    expect(page1_v1_instance.hash == page1_v2_instance.hash).to eq true
-    expect(title_v1_instance.hash == page1_v2_instance.hash).to eq false
+    expect(title_v1_instance.hash == title_v2_instance.hash).to be true
+    expect(page1_v1_instance.hash == page1_v2_instance.hash).to be true
+    expect(title_v1_instance.hash == page1_v2_instance.hash).to be false
   end
 end

--- a/spec/unit_tests/moab/file_inventory_difference_spec.rb
+++ b/spec/unit_tests/moab/file_inventory_difference_spec.rb
@@ -81,7 +81,7 @@ describe Moab::FileInventoryDifference do
     end
 
     specify 'unknown type returns nil' do
-      expect(diff_v1_v2.group_difference('dummy')).to eq nil
+      expect(diff_v1_v2.group_difference('dummy')).to be_nil
     end
   end
 

--- a/spec/unit_tests/moab/file_inventory_spec.rb
+++ b/spec/unit_tests/moab/file_inventory_spec.rb
@@ -112,12 +112,12 @@ describe Moab::FileInventory do
     group_id = 'content'
     group = parsed_file_inventory.group(group_id)
     expect(group.group_id).to eq group_id
-    expect(parsed_file_inventory.group('dummy')).to eq nil
+    expect(parsed_file_inventory.group('dummy')).to be_nil
   end
 
   specify '#group_empty?' do
-    expect(parsed_file_inventory.group_empty?('content')).to eq false
-    expect(parsed_file_inventory.group_empty?('dummy')).to eq true
+    expect(parsed_file_inventory.group_empty?('content')).to be false
+    expect(parsed_file_inventory.group_empty?('dummy')).to be true
   end
 
   specify '#file_signature' do

--- a/spec/unit_tests/moab/file_manifestation_spec.rb
+++ b/spec/unit_tests/moab/file_manifestation_spec.rb
@@ -66,6 +66,6 @@ describe Moab::FileManifestation do
 
   specify '#==' do
     other = file_manifestation
-    expect(file_manifestation == other).to eq true
+    expect(file_manifestation == other).to be true
   end
 end

--- a/spec/unit_tests/moab/file_signature_spec.rb
+++ b/spec/unit_tests/moab/file_signature_spec.rb
@@ -99,19 +99,19 @@ describe Moab::FileSignature do
   end
 
   specify '#eql?' do
-    expect(title_v1_signature.eql?(title_v2_signature)).to eq true
-    expect(page1_v1_signature.eql?(page1_v2_signature)).to eq false
+    expect(title_v1_signature.eql?(title_v2_signature)).to be true
+    expect(page1_v1_signature.eql?(page1_v2_signature)).to be false
   end
 
   specify '#==' do
-    expect(title_v1_signature == title_v2_signature).to eq true
-    expect(page1_v1_signature == page1_v2_signature).to eq false
+    expect(title_v1_signature == title_v2_signature).to be true
+    expect(page1_v1_signature == page1_v2_signature).to be false
   end
 
   specify '#hash' do
     expect(title_v1_signature.hash).to be_kind_of Numeric
-    expect(title_v1_signature.hash == title_v2_signature.hash).to eq true
-    expect(page1_v1_signature.hash == page1_v2_signature.hash).to eq false
+    expect(title_v1_signature.hash == title_v2_signature.hash).to be true
+    expect(page1_v1_signature.hash == page1_v2_signature.hash).to be false
   end
 
   specify '#signature_from_file' do

--- a/spec/unit_tests/moab/storage_object_spec.rb
+++ b/spec/unit_tests/moab/storage_object_spec.rb
@@ -36,11 +36,11 @@ describe Moab::StorageObject do
 
   specify '#initialize_storage' do
     @temp_object_dir.rmtree if @temp_object_dir.exist?
-    expect(@temp_object_dir.exist?).to eq false
-    expect(@storage_object.exist?).to eq false
+    expect(@temp_object_dir.exist?).to be false
+    expect(@storage_object.exist?).to be false
     @storage_object.initialize_storage
-    expect(@temp_object_dir.exist?).to eq true
-    expect(@storage_object.exist?).to eq true
+    expect(@temp_object_dir.exist?).to be true
+    expect(@storage_object.exist?).to be true
   end
 
   specify '#deposit_home' do
@@ -131,11 +131,11 @@ describe Moab::StorageObject do
 
       bag_dir.join('versionInventory.xml').delete
       bag_dir.join('versionAdditions.xml').delete
-      expect(bag_dir.join('versionInventory.xml').exist?).to eq false
-      expect(bag_dir.join('versionAdditions.xml').exist?).to eq false
+      expect(bag_dir.join('versionInventory.xml').exist?).to be false
+      expect(bag_dir.join('versionAdditions.xml').exist?).to be false
       described_class.new(@druid, object_dir).ingest_bag(bag_dir)
-      expect(bag_dir.join('versionInventory.xml').exist?).to eq true
-      expect(bag_dir.join('versionAdditions.xml').exist?).to eq true
+      expect(bag_dir.join('versionInventory.xml').exist?).to be true
+      expect(bag_dir.join('versionAdditions.xml').exist?).to be true
       ingests_dir.rmtree if ingests_dir.exist? # cleanup
     end
   end
@@ -406,7 +406,7 @@ describe Moab::StorageObject do
 
     version_inventory_4 = double("#{Moab::FileInventory.name}4")
     expect(version_inventory_4).to receive(:version_id).and_return 4
-    expect(storage_object.validate_new_inventory(version_inventory_4)).to eq true
+    expect(storage_object.validate_new_inventory(version_inventory_4)).to be true
   end
 
   describe '#find_object_version' do
@@ -457,7 +457,7 @@ describe Moab::StorageObject do
   end
 
   specify '#verify_object_storage' do
-    expect(storage_object.verify_object_storage.verified).to eq true
+    expect(storage_object.verify_object_storage.verified).to be true
   end
 
   specify '#restore_object' do

--- a/spec/unit_tests/moab/storage_object_validator_spec.rb
+++ b/spec/unit_tests/moab/storage_object_validator_spec.rb
@@ -226,7 +226,7 @@ describe Moab::StorageObjectValidator do
       let(:druid_path) { 'spec/fixtures/good_root01/moab_storage_trunk/bj/103/hs/9687/bj103hs9687' }
 
       it "returns true when moab is in correct format" do
-        expect(error_list.empty?).to eq true
+        expect(error_list.empty?).to be true
       end
 
       context 'manifest directory' do

--- a/spec/unit_tests/moab/storage_object_version_spec.rb
+++ b/spec/unit_tests/moab/storage_object_version_spec.rb
@@ -283,18 +283,18 @@ describe Moab::StorageObjectVersion do
     temp_storage_object_version.ingest_file(vers_add_file, temp_version_pathname)
 
     temp_storage_object_version.generate_manifest_inventory
-    expect(Moab::FileInventory.xml_pathname_exist?(temp_version_pathname.join('manifests'), 'manifests')).to eq true
+    expect(Moab::FileInventory.xml_pathname_exist?(temp_version_pathname.join('manifests'), 'manifests')).to be true
   end
 
   specify '#verify_version_storage' do
     result = @existing_storage_object_version.verify_version_storage
-    expect(result.verified).to eq true
+    expect(result.verified).to be true
   end
 
   describe '#verify_manifest_inventory' do
     it 'when files match, VerificationResult.verified is true' do
       result = @existing_storage_object_version.verify_manifest_inventory
-      expect(result.verified).to eq true
+      expect(result.verified).to be true
     end
 
     context 'when files do not match' do
@@ -303,7 +303,7 @@ describe Moab::StorageObjectVersion do
       end
 
       it 'VerificationResult.verified is false' do
-        expect(@result.verified).to eq false
+        expect(@result.verified).to be false
       end
 
       it 'VerificationResult.to_hash has expected content' do
@@ -373,7 +373,7 @@ describe Moab::StorageObjectVersion do
     end
 
     it 'VerificationResult.verified is true' do
-      expect(@result.verified).to eq true
+      expect(@result.verified).to be true
     end
 
     it 'VerificationResult.to_hash has expected content' do
@@ -411,7 +411,7 @@ describe Moab::StorageObjectVersion do
     end
 
     it 'VerificationResult.verified is true' do
-      expect(@result.verified).to eq true
+      expect(@result.verified).to be true
     end
 
     it 'VerificationResult.to_hash has expected content' do
@@ -453,7 +453,7 @@ describe Moab::StorageObjectVersion do
   describe '#verify_version_additions' do
     it 'when files match, VerificationResult.verified is true' do
       result = @existing_storage_object_version.verify_version_additions
-      expect(result.verified).to eq true
+      expect(result.verified).to be true
     end
 
     context 'when files do not match' do
@@ -462,7 +462,7 @@ describe Moab::StorageObjectVersion do
       end
 
       it 'VerificationResult.verified is false' do
-        expect(@result.verified).to eq false
+        expect(@result.verified).to be false
       end
 
       it 'VerificationResult.to_hash has expected content' do
@@ -540,9 +540,9 @@ describe Moab::StorageObjectVersion do
     so = Moab::StorageObject.new(@druid, @temp_object_dir)
     version = so.storage_object_version(version_id)
     timestamp = Time.now
-    expect(version.exist?).to eq true
+    expect(version.exist?).to be true
     version.deactivate(timestamp)
-    expect(version.exist?).to eq false
+    expect(version.exist?).to be false
     inactive_location = @temp_object_dir.join(timestamp.utc.iso8601.gsub(/[-:]/, ''))
     expect(inactive_location.children.size).to eq 1
   end

--- a/spec/unit_tests/moab/utc_time_spec.rb
+++ b/spec/unit_tests/moab/utc_time_spec.rb
@@ -6,7 +6,7 @@ describe Moab::UtcTime do
 
   describe '.input' do
     it 'nil returns nil' do
-      expect(described_class.input(nil)).to eq nil
+      expect(described_class.input(nil)).to be_nil
     end
 
     it 'returns Time.parse() of string value' do

--- a/spec/unit_tests/moab/verification_result_spec.rb
+++ b/spec/unit_tests/moab/verification_result_spec.rb
@@ -22,7 +22,7 @@ describe Moab::VerificationResult do
   specify '.verify_value' do
     result = described_class.verify_value('greeting', "hello", "goodbye")
     expect(result.entity).to eq 'greeting'
-    expect(result.verified).to eq false
+    expect(result.verified).to be false
     expect(result.details).to eq("expected" => "hello", "found" => "goodbye")
     expect(result.subentities).to be_an_instance_of Array
     expect(result.subentities.size).to eq 0
@@ -31,8 +31,8 @@ describe Moab::VerificationResult do
   specify '.verify_truth' do
     result = described_class.verify_truth('truth', "true")
     expect(result.entity).to eq 'truth'
-    expect(result.verified).to eq true
-    expect(result.details).to eq nil
+    expect(result.verified).to be true
+    expect(result.details).to be_nil
     expect(result.subentities).to be_an_instance_of Array
     expect(result.subentities.size).to eq 0
   end
@@ -40,8 +40,8 @@ describe Moab::VerificationResult do
   specify '#initialize' do
     result = described_class.new('my_entity')
     expect(result.entity).to eq 'my_entity'
-    expect(result.verified).to eq false
-    expect(result.details).to eq nil
+    expect(result.verified).to be false
+    expect(result.details).to be_nil
     expect(result.subentities).to be_an_instance_of Array
   end
 

--- a/spec/unit_tests/serializer/manifest_spec.rb
+++ b/spec/unit_tests/serializer/manifest_spec.rb
@@ -24,8 +24,8 @@ describe Serializer::Manifest do
   end
 
   specify '.xml_pathname_exist?' do
-    expect(described_class.xml_pathname_exist?("/test/parent_dir", "dummy")).to eq(false)
-    expect(Moab::SignatureCatalog.xml_pathname_exist?(@manifests.join("v0001"))).to eq(true)
+    expect(described_class.xml_pathname_exist?("/test/parent_dir", "dummy")).to be(false)
+    expect(Moab::SignatureCatalog.xml_pathname_exist?(@manifests.join("v0001"))).to be(true)
   end
 
   specify '.read_xml_file' do

--- a/spec/unit_tests/serializer/serializable_spec.rb
+++ b/spec/unit_tests/serializer/serializable_spec.rb
@@ -123,7 +123,7 @@ describe Serializer::Serializable do
     end
 
     it 'nil for FileSignature' do
-      expect(Moab::FileSignature.new.key_name).to eq(nil)
+      expect(Moab::FileSignature.new.key_name).to be_nil
     end
   end
 
@@ -142,7 +142,7 @@ describe Serializer::Serializable do
 
     it 'FileSignature key is nil' do
       file_signature = Moab::FileSignature.new
-      expect(file_signature.key).to eq(nil)
+      expect(file_signature.key).to be_nil
     end
   end
 

--- a/spec/unit_tests/stanford/content_inventory_spec.rb
+++ b/spec/unit_tests/stanford/content_inventory_spec.rb
@@ -213,7 +213,7 @@ describe Stanford::ContentInventory do
   describe '#validate_content_metadata' do
     it 'returns true when valid data' do
       cm = @fixtures.join('data', 'jq937jp0017', 'v0001', 'metadata', 'contentMetadata.xml').read
-      expect(@content_inventory.validate_content_metadata(cm)).to eq(true)
+      expect(@content_inventory.validate_content_metadata(cm)).to be(true)
     end
 
     it 'raises Moab::InvalidMetadataException for bad data' do


### PR DESCRIPTION
## Why was this change made? 🤔

Enables new cops to quiet warnings, autocorrect to fix correctable issues.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to filesystem, or what is expected to be read from filesystem), run ***[integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** on stage as it tests preservation, and/or test in stage environment, in addition to specs.⚡


