### PR TITLE
Gemfile.lock updated - Run bundle install

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     ast (2.4.2)
+    byebug (11.1.3)
+    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     deprecation (1.1.0)
       activesupport
@@ -28,7 +30,10 @@ GEM
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     json (2.6.2)
+    method_source (1.0.0)
     minitest (5.16.2)
+    nokogiri (1.13.6-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.6-x86_64-linux)
       racc (~> 1.4)
     nokogiri-happymapper (0.9.0)
@@ -36,6 +41,12 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     racc (1.6.0)
     rainbow (3.1.1)
     rake (13.0.6)
@@ -80,11 +91,13 @@ GEM
     unicode-display_width (2.2.0)
 
 PLATFORMS
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
   equivalent-xml
   moab-versioning!
+  pry-byebug
   rake
   rspec
   rubocop (~> 1.7)


### PR DESCRIPTION
## Why was this change made? 🤔
This updated the Gemfile.lock. I supect the previous version was created with `CI="true"` in the environment. https://github.com/sul-dlss/moab-versioning/blob/main/moab-versioning.gemspec#L26


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to filesystem, or what is expected to be read from filesystem), run ***[integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** on stage as it tests preservation, and/or test in stage environment, in addition to specs.⚡


