### PR TITLE
Performance improvement in storage_object_version.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     ast (2.4.2)
+    byebug (11.1.3)
+    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     deprecation (1.1.0)
       activesupport
@@ -28,6 +30,7 @@ GEM
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.2)
+    method_source (1.0.0)
     minitest (5.16.2)
     nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
@@ -38,6 +41,12 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     racc (1.6.0)
     rainbow (3.1.1)
     rake (13.0.6)
@@ -89,6 +98,7 @@ PLATFORMS
 DEPENDENCIES
   equivalent-xml
   moab-versioning!
+  pry-byebug
   rake
   rspec
   rubocop (~> 1.7)

--- a/lib/moab/storage_object_version.rb
+++ b/lib/moab/storage_object_version.rb
@@ -128,11 +128,11 @@ module Moab
     # @api external
     # @return [SignatureCatalog] The signature catalog of the digital object as of this version
     def signature_catalog
-      if version_id > 0
-        SignatureCatalog.read_xml_file(@version_pathname.join('manifests'))
-      else
-        SignatureCatalog.new(digital_object_id: @storage_object.digital_object_id)
-      end
+      @signature_catalog ||= if version_id > 0
+                               SignatureCatalog.read_xml_file(@version_pathname.join('manifests'))
+                             else
+                               SignatureCatalog.new(digital_object_id: @storage_object.digital_object_id)
+                             end
     end
 
     # @api internal


### PR DESCRIPTION
## Why was this change made? 🤔
Performance


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to filesystem, or what is expected to be read from filesystem), run ***[integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** on stage as it tests preservation, and/or test in stage environment, in addition to specs.⚡

techmd-prod

It reduced listing files for an item with 421 files from 162 seconds to 1.23 seconds. Verified that the results were the same.
