### PR TITLE
silence spec warnings for already initialized constant

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -181,3 +181,11 @@ def fixture_setup
   #end
 end
 # rubocop:enable Metrics/AbcSize
+
+def silence_warnings(&block)
+  warn_level = $VERBOSE
+  $VERBOSE = nil
+  result = block.call
+  $VERBOSE = warn_level
+  result
+end

--- a/spec/unit_tests/moab/storage_object_validator_spec.rb
+++ b/spec/unit_tests/moab/storage_object_validator_spec.rb
@@ -7,9 +7,15 @@ describe Moab::StorageObjectValidator do
   let(:storage_obj_validator) { described_class.new(storage_obj) }
   let(:error_list) { storage_obj_validator.validation_errors }
 
-  before { described_class::IMPLICIT_DIRS = ['.', '..', '.keep'].freeze }
+  before do
+    # avoid warning: already initialized constant
+    silence_warnings { described_class::IMPLICIT_DIRS = ['.', '..', '.keep'].freeze }
+  end
 
-  after { described_class::IMPLICIT_DIRS = ['.', '..'].freeze }
+  after do
+    # put it back to normal and avoid warning: already initialized constant
+    silence_warnings { described_class::IMPLICIT_DIRS = ['.', '..'].freeze }
+  end
 
   describe '#initialize' do
     it 'sets storage_obj_path' do

--- a/spec/unit_tests/stanford/storage_object_validator_spec.rb
+++ b/spec/unit_tests/stanford/storage_object_validator_spec.rb
@@ -7,9 +7,15 @@ RSpec.describe Stanford::StorageObjectValidator do
   let(:storage_obj_validator) { described_class.new(storage_obj) }
   let(:error_list) { storage_obj_validator.validation_errors }
 
-  before { Moab::StorageObjectValidator::IMPLICIT_DIRS = ['.', '..', '.keep'].freeze }
+  before do
+    # avoid warning: already initialized constant
+    silence_warnings { Moab::StorageObjectValidator::IMPLICIT_DIRS = ['.', '..', '.keep'].freeze }
+  end
 
-  after { Moab::StorageObjectValidator::IMPLICIT_DIRS = ['.', '..'].freeze }
+  after do
+    # put it back to normal and avoid warning: already initialized constant
+    silence_warnings { Moab::StorageObjectValidator::IMPLICIT_DIRS = ['.', '..'].freeze }
+  end
 
   describe '#validation_errors' do
     context 'calling superclass validation_errors' do


### PR DESCRIPTION
## Why was this change made? 🤔

One small step towards better spec practices.  Part of #194.

Removes this noise from spec running output:

(below is only 1/2 of the noise)

```
/Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:10: warning: already initialized constant Moab::StorageObjectValidator::IMPLICIT_DIRS
/Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/moab/storage_object_validator_spec.rb:12: warning: previous definition of IMPLICIT_DIRS was here
/Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:12: warning: already initialized constant Moab::StorageObjectValidator::IMPLICIT_DIRS
/Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:10: warning: previous definition of IMPLICIT_DIRS was here
./Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:10: warning: already initialized constant Moab::StorageObjectValidator::IMPLICIT_DIRS
/Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:12: warning: previous definition of IMPLICIT_DIRS was here
/Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:12: warning: already initialized constant Moab::StorageObjectValidator::IMPLICIT_DIRS
/Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:10: warning: previous definition of IMPLICIT_DIRS was here
./Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:10: warning: already initialized constant Moab::StorageObjectValidator::IMPLICIT_DIRS
/Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:12: warning: previous definition of IMPLICIT_DIRS was here
/Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:12: warning: already initialized constant Moab::StorageObjectValidator::IMPLICIT_DIRS
/Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:10: warning: previous definition of IMPLICIT_DIRS was here
./Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:10: warning: already initialized constant Moab::StorageObjectValidator::IMPLICIT_DIRS
/Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:12: warning: previous definition of IMPLICIT_DIRS was here
/Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:12: warning: already initialized constant Moab::StorageObjectValidator::IMPLICIT_DIRS
/Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:10: warning: previous definition of IMPLICIT_DIRS was here
./Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:10: warning: already initialized constant Moab::StorageObjectValidator::IMPLICIT_DIRS
/Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:12: warning: previous definition of IMPLICIT_DIRS was here
/Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:12: warning: already initialized constant Moab::StorageObjectValidator::IMPLICIT_DIRS
/Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:10: warning: previous definition of IMPLICIT_DIRS was here
./Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:10: warning: already initialized constant Moab::StorageObjectValidator::IMPLICIT_DIRS
/Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:12: warning: previous definition of IMPLICIT_DIRS was here
/Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:12: warning: already initialized constant Moab::StorageObjectValidator::IMPLICIT_DIRS
/Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:10: warning: previous definition of IMPLICIT_DIRS was here
./Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:10: warning: already initialized constant Moab::StorageObjectValidator::IMPLICIT_DIRS
/Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:12: warning: previous definition of IMPLICIT_DIRS was here
/Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:12: warning: already initialized constant Moab::StorageObjectValidator::IMPLICIT_DIRS
/Users/ndushay/sul-dlss-github/moab-versioning/spec/unit_tests/stanford/storage_object_validator_spec.rb:10: warning: previous definition of IMPLICIT_DIRS was here
```

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to filesystem, or what is expected to be read from filesystem), run ***[integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** on stage as it tests preservation, and/or test in stage environment, in addition to specs.⚡


