### PR TITLE
specs use 'it' instead of 'specify'

### DIFF
--- a/spec/unit_tests/moab/bagger_spec.rb
+++ b/spec/unit_tests/moab/bagger_spec.rb
@@ -39,7 +39,7 @@ describe Moab::Bagger do
   let(:submit_inventory) { Moab::FileInventory.read_xml_file(manifests_dir.join('v0002'), 'version') }
   let(:submit_source_base) { data_dir.join('v0002') }
 
-  specify '#initialize' do
+  it '#initialize' do
     version_inventory = double(Moab::FileInventory.name)
     signature_catalog = double(Moab::SignatureCatalog.name)
     bag_pathname = temp_dir.join('bag_pathname')
@@ -49,7 +49,7 @@ describe Moab::Bagger do
     expect(bagger.bag_pathname).to eq bag_pathname
   end
 
-  specify '#delete_bag' do
+  it '#delete_bag' do
     packages = temp_dir.join('packages')
     bag_dir = packages.join('deleteme')
     bag_data_dir = bag_dir.join('data')
@@ -60,7 +60,7 @@ describe Moab::Bagger do
     expect(bag_dir.exist?).to be false
   end
 
-  specify '#delete_tarfile' do
+  it '#delete_tarfile' do
     packages = temp_dir.join('packages')
     tar_file = packages.join('deleteme.tar')
     tar_file.open('w') { |f| f.puts "delete me please" }
@@ -224,7 +224,7 @@ describe Moab::Bagger do
     end
   end
 
-  specify '#create_payload_manifests' do
+  it '#create_payload_manifests' do
     submit_bag.fill_payload(submit_source_base)
     submit_bag.create_payload_manifests
     md5 = submit_bag.bag_pathname.join('manifest-md5.txt')
@@ -245,7 +245,7 @@ describe Moab::Bagger do
     ]
   end
 
-  specify '#create_bag_info_txt' do
+  it '#create_bag_info_txt' do
     submit_bag.create_bag_info_txt
     bag_info = submit_bag.bag_pathname.join('bag-info.txt')
     expect(bag_info.exist?).to be true
@@ -256,7 +256,7 @@ describe Moab::Bagger do
     ]
   end
 
-  specify '#create_bagit_txt' do
+  it '#create_bagit_txt' do
     submit_bag.create_bagit_txt
     bagit = submit_bag.bag_pathname.join('bagit.txt')
     expect(bagit.exist?).to be true
@@ -266,7 +266,7 @@ describe Moab::Bagger do
     ]
   end
 
-  specify '#create_tagfile_manifests' do
+  it '#create_tagfile_manifests' do
     expect(submit_bag).to receive(:create_tagfile_manifests).and_call_original
     submit_bag.fill_bag(:depositor, submit_source_base)
     md5 = submit_bag.bag_pathname.join('tagmanifest-md5.txt')
@@ -294,7 +294,7 @@ describe Moab::Bagger do
     ]
   end
 
-  specify '#create_tarfile' do
+  it '#create_tarfile' do
     bag_dir = packages_dir.join('v0001')
     tarfile = temp_dir.join('test.tar')
     bagger = described_class.new(nil, nil, bag_dir)

--- a/spec/unit_tests/moab/file_group_difference_spec.rb
+++ b/spec/unit_tests/moab/file_group_difference_spec.rb
@@ -12,48 +12,48 @@ describe Moab::FileGroupDifference do
   end
 
   describe '#initialize' do
-    specify 'empty options hash' do
+    it 'empty options hash' do
       diff = described_class.new({})
       expect(diff.subsets).to be_kind_of Array
       expect(diff.subsets.size).to eq 0
     end
 
-    specify 'options passed in' do
+    it 'options passed in' do
       opts = { group_id: 'Test group_id' }
       diff = described_class.new(opts)
       expect(diff.group_id).to eq opts[:group_id]
     end
   end
 
-  specify '#group_id' do
+  it '#group_id' do
     expect(group_diff.group_id).to eq "content"
   end
 
-  specify '#difference_count' do
+  it '#difference_count' do
     expect(group_diff.difference_count).to eq 6
   end
 
-  specify '#identical' do
+  it '#identical' do
     expect(group_diff.identical).to eq 1
   end
 
-  specify '#renamed' do
+  it '#renamed' do
     expect(group_diff.renamed).to eq 2
   end
 
-  specify '#modified' do
+  it '#modified' do
     expect(group_diff.modified).to eq 1
   end
 
-  specify '#deleted' do
+  it '#deleted' do
     expect(group_diff.deleted).to eq 2
   end
 
-  specify '#added' do
+  it '#added' do
     expect(group_diff.added).to eq 1
   end
 
-  specify '#subsets' do
+  it '#subsets' do
     expect(group_diff.subsets.size).to be >= 5
   end
 
@@ -69,7 +69,7 @@ describe Moab::FileGroupDifference do
   end
   let(:new_diff) { described_class.new }
 
-  specify '#summary' do
+  it '#summary' do
     summary = new_diff.compare_file_groups(v1_content, v3_content).summary()
     expect(summary).to be_instance_of described_class
     summary.group_id = ''
@@ -87,19 +87,19 @@ describe Moab::FileGroupDifference do
     let(:other_hash) { v3_content.path_hash }
     # basis_hash.keys: ["intro-1.jpg", "intro-2.jpg", "page-1.jpg", "page-2.jpg", "page-3.jpg", "title.jpg"]
     # other_hash.keys: ["page-1.jpg", "page-2.jpg", "page-3.jpg", "page-4.jpg", "title.jpg"]
-    specify '#matching_keys' do
+    it '#matching_keys' do
       matching_keys = new_diff.matching_keys(basis_hash, other_hash)
       expect(matching_keys.size).to eq 4
       expect(matching_keys).to eq ["page-1.jpg", "page-2.jpg", "page-3.jpg", "title.jpg"]
     end
 
-    specify '#basis_only_keys' do
+    it '#basis_only_keys' do
       basis_only_keys = new_diff.basis_only_keys(basis_hash, other_hash)
       expect(basis_only_keys.size).to eq 2
       expect(basis_only_keys).to eq ["intro-1.jpg", "intro-2.jpg"]
     end
 
-    specify '#other_only_keys' do
+    it '#other_only_keys' do
       other_only_keys = new_diff.other_only_keys(basis_hash, other_hash)
       expect(other_only_keys.size).to eq 1
       expect(other_only_keys).to eq ["page-4.jpg"]
@@ -112,19 +112,19 @@ describe Moab::FileGroupDifference do
     # basis_group.group_id: "content"
     # basis_group.data_source: includes "data/jq937jp0017/v0001/content"
     # other_group.data_source: includes "data/jq937jp0017/v0003/content"
-    specify 'calls compare_xxx_signatures methods' do
+    it 'calls compare_xxx_signatures methods' do
       expect(new_diff).to receive(:compare_matching_signatures).with(basis_group, other_group)
       expect(new_diff).to receive(:compare_non_matching_signatures).with(basis_group, other_group)
       new_diff.compare_file_groups(basis_group, other_group)
     end
 
-    specify 'returns itself, populated object' do
+    it 'returns itself, populated object' do
       return_value = new_diff.compare_file_groups(basis_group, other_group)
       expect(return_value).to eq new_diff
       expect(new_diff.group_id).to eq basis_group.group_id
     end
 
-    specify 'with empty group' do
+    it 'with empty group' do
       empty_group = Moab::FileGroup.new(group_id: "content")
       diff = new_diff.compare_file_groups(v1_content, empty_group)
       expect(diff.difference_count).to eq 6
@@ -174,7 +174,7 @@ describe Moab::FileGroupDifference do
         new_diff.compare_file_groups(basis_file_group, other_file_group)
       end
 
-      specify 'sets attributes' do
+      it 'sets attributes' do
         expect(comp_file_groups_diff.difference_count).to eq 3
         expect(comp_file_groups_diff.identical).to eq 2
         expect(comp_file_groups_diff.copyadded).to eq 1
@@ -182,7 +182,7 @@ describe Moab::FileGroupDifference do
         expect(comp_file_groups_diff.renamed).to eq 1
       end
 
-      specify 'copyadded subset' do
+      it 'copyadded subset' do
         copyadded_ng_xml = Nokogiri::XML(comp_file_groups_diff.subset_hash[:copyadded].to_xml)
         exp_ng_xml = Nokogiri::XML <<-XML
           <subset change="copyadded" count="1">
@@ -194,7 +194,7 @@ describe Moab::FileGroupDifference do
         expect(EquivalentXml.equivalent?(copyadded_ng_xml, exp_ng_xml, eq_xml_opts)).to be true
       end
 
-      specify 'copydeleted subset' do
+      it 'copydeleted subset' do
         copydeleted_ng_xml = Nokogiri::XML(comp_file_groups_diff.subset_hash[:copydeleted].to_xml)
         exp_ng_xml = Nokogiri::XML <<-XML
           <subset change="copydeleted" count="1">
@@ -206,7 +206,7 @@ describe Moab::FileGroupDifference do
         expect(EquivalentXml.equivalent?(copydeleted_ng_xml, exp_ng_xml, eq_xml_opts)).to be true
       end
 
-      specify 'renamed subset' do
+      it 'renamed subset' do
         renamed_ng_xml = Nokogiri::XML(comp_file_groups_diff.subset_hash[:renamed].to_xml)
         exp_ng_xml = Nokogiri::XML <<-XML
           <subset change="renamed" count="1">
@@ -220,7 +220,7 @@ describe Moab::FileGroupDifference do
     end
   end
 
-  specify '#compare_matching_signatures' do
+  it '#compare_matching_signatures' do
     new_diff.compare_matching_signatures(v1_content, v3_content)
     expect(new_diff.subsets.size).to eq 2
     expect(new_diff.subsets.collect(&:change)).to eq %w[identical renamed]
@@ -229,7 +229,7 @@ describe Moab::FileGroupDifference do
     expect(new_diff.renamed).to eq 2
   end
 
-  specify '#compare_non_matching_signatures' do
+  it '#compare_non_matching_signatures' do
     new_diff.compare_non_matching_signatures(v1_content, v3_content)
     expect(new_diff.subsets.size).to eq 3
     expect(new_diff.subsets.collect(&:change)).to eq %w[modified added deleted]
@@ -246,7 +246,7 @@ describe Moab::FileGroupDifference do
     # page-2.jpg, page-3.jpg, title.jpg
   end
 
-  specify '#tabulate_unchanged_files' do
+  it '#tabulate_unchanged_files' do
     new_diff.tabulate_unchanged_files(matching_keys_signatures, v1_content.signature_hash, v3_content.signature_hash)
     expect(new_diff.subset_hash.keys).to eq [:identical]
     unchanged_subset = new_diff.subset('identical')
@@ -267,7 +267,7 @@ describe Moab::FileGroupDifference do
     expect(unchanged_file.signatures[0].fixity).to eq title_jpg_fixity
   end
 
-  specify '#tabulate_renamed_files' do
+  it '#tabulate_renamed_files' do
     new_diff.tabulate_renamed_files(matching_keys_signatures, v1_content.signature_hash, v3_content.signature_hash)
     renamed_subset = new_diff.subset('renamed')
     expect(renamed_subset).to be_instance_of Moab::FileGroupDifferenceSubset
@@ -308,7 +308,7 @@ describe Moab::FileGroupDifference do
     v3_content.path_hash_subset(other_only_signatures)
     # NOTE: other_path_hash.keys: page-1.jpg, page-2.jpg, page-3.jpg, page-4.jpg, title.jpg
   end
-  specify '#tabulate_modified_files' do
+  it '#tabulate_modified_files' do
     new_diff.tabulate_modified_files(basis_path_hash, other_path_hash)
     modified_subset = new_diff.subset('modified')
     expect(modified_subset).to be_instance_of Moab::FileGroupDifferenceSubset
@@ -328,7 +328,7 @@ describe Moab::FileGroupDifference do
     expect(modified_file.signatures[0].fixity).to eq page_1_jpg_fixity
   end
 
-  specify '#tabulate_deleted_files' do
+  it '#tabulate_deleted_files' do
     new_diff.tabulate_deleted_files(basis_path_hash, other_path_hash)
     deleted_subset = new_diff.subset('deleted')
     expect(deleted_subset).to be_instance_of Moab::FileGroupDifferenceSubset
@@ -359,7 +359,7 @@ describe Moab::FileGroupDifference do
     expect(deleted_file2.signatures[0].fixity).to eq intro_2_jpg_fixity
   end
 
-  specify '#tabulate_added_files' do
+  it '#tabulate_added_files' do
     new_diff.tabulate_added_files(basis_path_hash, other_path_hash)
     added_subset = new_diff.subset('added')
     expect(added_subset).to be_instance_of Moab::FileGroupDifferenceSubset
@@ -379,7 +379,7 @@ describe Moab::FileGroupDifference do
     expect(added_file.signatures[0].fixity).to eq page_2_jpg_fixity
   end
 
-  specify '.parse' do
+  it '.parse' do
     fixture = ingests_dir.join('jq937jp0017', 'v0003', 'manifests', 'fileInventoryDifference.xml')
     fid = Moab::FileInventoryDifference.parse(File.read(fixture))
     fgd = fid.group_difference('content')
@@ -394,7 +394,7 @@ describe Moab::FileGroupDifference do
     expect(fgd.subset('added').files[0].other_path).to eq "page-2.jpg"
   end
 
-  specify '#file_deltas' do
+  it '#file_deltas' do
     deltas = new_diff.file_deltas
     expect(deltas).to eq(
       identical: [],
@@ -418,14 +418,14 @@ describe Moab::FileGroupDifference do
     )
   end
 
-  specify '#rename_require_temp_files' do
+  it '#rename_require_temp_files' do
     renamed = [["page-2.jpg", "page-3.jpg"], ["page-3.jpg", "page-4.jpg"]]
     expect(new_diff.rename_require_temp_files(renamed)).to be true
     renamed = [["page-1.jpg", "page-1b.jpg"], ["page-2.jpg", "page-2b.jpg"]]
     expect(new_diff.rename_require_temp_files(renamed)).to be false
   end
 
-  specify '#rename_tempfile_triplets' do
+  it '#rename_tempfile_triplets' do
     renamed = [["page-2.jpg", "page-3.jpg"], ["page-3.jpg", "page-4.jpg"]]
     triplets = new_diff.rename_tempfile_triplets(renamed)
     expect(triplets[0][0]).to eq "page-2.jpg"

--- a/spec/unit_tests/moab/file_group_difference_subset_spec.rb
+++ b/spec/unit_tests/moab/file_group_difference_subset_spec.rb
@@ -4,12 +4,12 @@ describe Moab::FileGroupDifferenceSubset do
   let(:diff_subset) { described_class.new }
 
   describe '#initialize' do
-    specify 'empty options hash' do
+    it 'empty options hash' do
       diff_subset = described_class.new({})
       expect(diff_subset.files).to eq []
     end
 
-    specify 'options passed in' do
+    it 'options passed in' do
       opts = { change: 'Test change' }
       diff_subset = described_class.new(opts)
       expect(diff_subset.change).to eq opts[:change]
@@ -17,12 +17,12 @@ describe Moab::FileGroupDifferenceSubset do
     end
   end
 
-  specify '#count is computed, not set' do
+  it '#count is computed, not set' do
     diff_subset.count = 52
     expect(diff_subset.count).to eq 0
   end
 
-  specify '#files is computed, not set' do
+  it '#files is computed, not set' do
     expect(diff_subset.files.size).to eq 0
   end
 end

--- a/spec/unit_tests/moab/file_instance_difference_spec.rb
+++ b/spec/unit_tests/moab/file_instance_difference_spec.rb
@@ -2,12 +2,12 @@
 
 describe Moab::FileInstanceDifference do
   describe '#initialize' do
-    specify 'empty options hash' do
+    it 'empty options hash' do
       diff = described_class.new({})
       expect(diff.signatures).to eq []
     end
 
-    specify 'options passed in' do
+    it 'options passed in' do
       opts = {
         change: 'Test change',
         basis_path: 'Test basis_path',

--- a/spec/unit_tests/moab/file_instance_spec.rb
+++ b/spec/unit_tests/moab/file_instance_spec.rb
@@ -20,7 +20,7 @@ describe Moab::FileInstance do
     described_class.new.instance_from_file(page1_v2_pathname, v2_base_directory)
   end
 
-  specify '#initialize' do
+  it '#initialize' do
     opts = {
       path: temp_dir.join('path').to_s,
       datetime: "Apr 18 21:51:31 UTC 2012"
@@ -30,30 +30,30 @@ describe Moab::FileInstance do
     expect(file_instance.datetime).to eq "2012-04-18T21:51:31Z"
   end
 
-  specify '#datetime reformats as ISO8601 (UTC Z format)' do
+  it '#datetime reformats as ISO8601 (UTC Z format)' do
     fi = described_class.new
     fi.datetime = "Wed Apr 18 21:51:31 UTC 2012"
     expect(fi.datetime).to eq "2012-04-18T21:51:31Z"
   end
 
-  specify '#instance_from_file' do
+  it '#instance_from_file' do
     expect(title_v1_instance.path).to eq "title.jpg"
     expect(title_v1_instance.datetime).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/)
   end
 
-  specify '#eql?' do
+  it '#eql?' do
     expect(title_v1_instance.eql?(title_v2_instance)).to be true
     expect(page1_v1_instance.eql?(page1_v2_instance)).to be true
     expect(title_v1_instance.eql?(page1_v2_instance)).to be false
   end
 
-  specify '#==' do
+  it '#==' do
     expect(title_v1_instance == title_v2_instance).to be true
     expect(page1_v1_instance == page1_v2_instance).to be true
     expect(title_v1_instance == page1_v2_instance).to be false
   end
 
-  specify '#hash' do
+  it '#hash' do
     expect(title_v1_instance.hash == title_v2_instance.hash).to be true
     expect(page1_v1_instance.hash == page1_v2_instance.hash).to be true
     expect(title_v1_instance.hash == page1_v2_instance.hash).to be false

--- a/spec/unit_tests/moab/file_inventory_difference_spec.rb
+++ b/spec/unit_tests/moab/file_inventory_difference_spec.rb
@@ -13,13 +13,13 @@ describe Moab::FileInventoryDifference do
   let(:diff_v1_v2) { new_diff.compare(v1_inventory, v2_inventory) }
 
   describe '#initialize' do
-    specify 'empty options hash' do
+    it 'empty options hash' do
       group_diffs = new_diff.group_differences
       expect(group_diffs).to be_kind_of Array
       expect(group_diffs.size).to eq 0
     end
 
-    specify 'options passed in' do
+    it 'options passed in' do
       opts = {
         digital_object_id: 'Test digital_object_id',
         basis: 'Test basis',
@@ -36,69 +36,69 @@ describe Moab::FileInventoryDifference do
   end
 
   describe '#compare' do
-    specify 'returns instance of FileInventoryDifference' do
+    it 'returns instance of FileInventoryDifference' do
       expect(diff_v1_v2).to be_instance_of(described_class)
     end
 
     context 'sets attributes' do
-      specify '#digital_object_id' do
+      it '#digital_object_id' do
         expect(diff_v1_v2.digital_object_id).to eq 'druid:jq937jp0017'
       end
 
-      specify '#difference_count' do
+      it '#difference_count' do
         expect(diff_v1_v2.difference_count).to eq 6
       end
 
-      specify '#basis' do
+      it '#basis' do
         expect(diff_v1_v2.basis).to eq 'v1'
       end
 
-      specify '#other' do
+      it '#other' do
         expect(diff_v1_v2.other).to eq 'v2'
       end
 
-      specify '#report_datetime' do
+      it '#report_datetime' do
         expect(Time.parse(diff_v1_v2.report_datetime)).to be_instance_of(Time)
       end
 
-      specify '#group_differences' do
+      it '#group_differences' do
         expect(diff_v1_v2.group_differences.size).to eq 2
       end
     end
   end
 
   describe '#report_datetime' do
-    specify 'reformats date as ISO8601 (UTC Z format)' do
+    it 'reformats date as ISO8601 (UTC Z format)' do
       new_diff.report_datetime = 'Apr 12 19:36:07 UTC 2012'
       expect(new_diff.report_datetime).to eq '2012-04-12T19:36:07Z'
     end
   end
 
   describe '#group_difference' do
-    specify '"content" has group_id "content"' do
+    it '"content" has group_id "content"' do
       group_diff = diff_v1_v2.group_difference 'content'
       expect(group_diff.group_id).to eq 'content'
     end
 
-    specify 'unknown type returns nil' do
+    it 'unknown type returns nil' do
       expect(diff_v1_v2.group_difference('dummy')).to be_nil
     end
   end
 
   describe '#common_object_id' do
-    specify 'different ids' do
+    it 'different ids' do
       basis_inventory = Moab::FileInventory.new(digital_object_id: 'druid:aa111bb2222')
       other_inventory = Moab::FileInventory.new(digital_object_id: 'druid:cc444dd5555')
       exp_id = 'druid:aa111bb2222|druid:cc444dd5555'
       expect(new_diff.common_object_id(basis_inventory, other_inventory)).to eq exp_id
     end
 
-    specify 'same id' do
+    it 'same id' do
       expect(new_diff.common_object_id(v1_inventory, v2_inventory)).to eq 'druid:jq937jp0017'
     end
   end
 
-  specify '#summary_fields' do
+  it '#summary_fields' do
     hash = diff_v1_v2.summary
     hash.delete('report_datetime')
     expect(hash).to eq('digital_object_id' => 'druid:jq937jp0017',
@@ -131,7 +131,7 @@ describe Moab::FileInventoryDifference do
                        })
   end
 
-  specify '#differences_detail' do
+  it '#differences_detail' do
     hash = diff_v1_v2.differences_detail
     expect(hash['group_differences'].size).to eq 2
   end

--- a/spec/unit_tests/moab/file_inventory_spec.rb
+++ b/spec/unit_tests/moab/file_inventory_spec.rb
@@ -9,35 +9,35 @@ describe Moab::FileInventory do
   end
 
   describe '.xml_filename' do
-    specify 'version' do
+    it 'version' do
       expect(described_class.xml_filename('version')).to eq 'versionInventory.xml'
     end
 
-    specify 'additions' do
+    it 'additions' do
       expect(described_class.xml_filename("additions")).to eq 'versionAdditions.xml'
     end
 
-    specify 'manifests' do
+    it 'manifests' do
       expect(described_class.xml_filename("manifests")).to eq 'manifestInventory.xml'
     end
 
-    specify 'directory' do
+    it 'directory' do
       expect(described_class.xml_filename("directory")).to eq 'directoryInventory.xml'
     end
 
-    specify 'unknown type raises ArgumentError' do
+    it 'unknown type raises ArgumentError' do
       expect { described_class.xml_filename("other") }.to raise_exception(ArgumentError, /unknown inventory type/)
     end
   end
 
   describe '#initialize' do
-    specify 'empty options hash' do
+    it 'empty options hash' do
       file_inventory = described_class.new({})
       expect(file_inventory.groups).to be_kind_of Array
       expect(file_inventory.groups.size).to eq 0
     end
 
-    specify 'options passed in' do
+    it 'options passed in' do
       opts = {
         type: 'Test type',
         digital_object_id: 'Test digital_object_id',
@@ -53,52 +53,52 @@ describe Moab::FileInventory do
   end
 
   describe '.parse sets attributes' do
-    specify '#type' do
+    it '#type' do
       expect(parsed_file_inventory.type).to eq 'version'
     end
 
-    specify '#digital_object_id' do
+    it '#digital_object_id' do
       expect(parsed_file_inventory.digital_object_id).to eq 'druid:jq937jp0017'
     end
 
-    specify '#version_id' do
+    it '#version_id' do
       expect(parsed_file_inventory.version_id).to eq 1
     end
 
-    specify '#composite_key' do
+    it '#composite_key' do
       expect(parsed_file_inventory.composite_key).to eq "druid:jq937jp0017-v0001"
     end
 
-    specify '#inventory_datetime' do
+    it '#inventory_datetime' do
       expect(parsed_file_inventory.inventory_datetime).to eq "2012-04-13T13:16:54Z"
     end
 
-    specify '#file_count' do
+    it '#file_count' do
       expect(parsed_file_inventory.file_count).to eq 11
     end
 
-    specify '#byte_count' do
+    it '#byte_count' do
       expect(parsed_file_inventory.byte_count).to eq 217820
     end
 
-    specify '#block_count' do
+    it '#block_count' do
       expect(parsed_file_inventory.block_count).to eq 216
     end
 
-    specify '#groups' do
+    it '#groups' do
       expect(parsed_file_inventory.groups.size).to eq 2
     end
 
-    specify '#human_size' do
+    it '#human_size' do
       expect(parsed_file_inventory.human_size).to eq "212.71 KB"
     end
 
-    specify '#package_id' do
+    it '#package_id' do
       expect(parsed_file_inventory.package_id).to eq "druid:jq937jp0017-v1"
     end
   end
 
-  specify '#non_empty_groups' do
+  it '#non_empty_groups' do
     expect(parsed_file_inventory.groups.size).to eq 2
     expect(parsed_file_inventory.group_ids).to eq %w[content metadata]
     parsed_file_inventory.groups << Moab::FileGroup.new(group_id: 'empty')
@@ -108,19 +108,19 @@ describe Moab::FileInventory do
     expect(parsed_file_inventory.group_ids(true)).to eq %w[content metadata]
   end
 
-  specify '#group' do
+  it '#group' do
     group_id = 'content'
     group = parsed_file_inventory.group(group_id)
     expect(group.group_id).to eq group_id
     expect(parsed_file_inventory.group('dummy')).to be_nil
   end
 
-  specify '#group_empty?' do
+  it '#group_empty?' do
     expect(parsed_file_inventory.group_empty?('content')).to be false
     expect(parsed_file_inventory.group_empty?('dummy')).to be true
   end
 
-  specify '#file_signature' do
+  it '#file_signature' do
     group_id = 'content'
     file_id = 'title.jpg'
     signature = parsed_file_inventory.file_signature(group_id, file_id)
@@ -133,7 +133,7 @@ describe Moab::FileInventory do
     expect(signature.fixity).to eq expected_sig_fixity
   end
 
-  specify '#copy_ids' do
+  it '#copy_ids' do
     new_file_inventory = described_class.new
     new_file_inventory.copy_ids(parsed_file_inventory)
     expect(new_file_inventory.digital_object_id).to eq parsed_file_inventory.digital_object_id
@@ -141,14 +141,14 @@ describe Moab::FileInventory do
     expect(new_file_inventory.inventory_datetime).to eq parsed_file_inventory.inventory_datetime
   end
 
-  specify '#data_source' do
+  it '#data_source' do
     expect(parsed_file_inventory.data_source).to eq "v1"
     directory = fixtures_dir.join('derivatives/manifests/all')
     directory_inventory = described_class.new(type: 'directory').inventory_from_directory(directory, "mygroup")
     expect(directory_inventory.data_source).to include "derivatives/manifests/all"
   end
 
-  specify '#inventory_from_directory' do
+  it '#inventory_from_directory' do
     data_dir_1 = fixtures_dir.join('data/jq937jp0017/v0001/metadata')
     group_id = 'Test group_id'
     inventory_1 = described_class.new.inventory_from_directory(data_dir_1, group_id)
@@ -164,7 +164,7 @@ describe Moab::FileInventory do
     expect(inventory_2.file_count).to eq 11
   end
 
-  specify '#inventory_from_bagit_bag' do
+  it '#inventory_from_bagit_bag' do
     bag_dir = packages_dir.join('v0001')
     inventory = described_class.new.inventory_from_bagit_bag(bag_dir)
     expect(inventory.groups.size).to eq 2
@@ -172,7 +172,7 @@ describe Moab::FileInventory do
     expect(inventory.file_count).to eq 11
   end
 
-  specify '#signatures_from_bagit_manifests' do
+  it '#signatures_from_bagit_manifests' do
     bag_pathname = packages_dir.join('v0001')
     signature_for_path = described_class.new.signatures_from_bagit_manifests(bag_pathname)
     expect(signature_for_path.size).to eq 11
@@ -180,7 +180,7 @@ describe Moab::FileInventory do
     expect(signature_for_path[packages_dir.join('v0001/data/content/page-2.jpg')].md5).to eq "82fc107c88446a3119a51a8663d1e955"
   end
 
-  specify '#write_xml_file' do
+  it '#write_xml_file' do
     parent_dir = temp_dir.join('parent_dir')
     type = 'Test type'
     expect(described_class).to receive(:write_xml_file).with(parsed_file_inventory, parent_dir, type)
@@ -188,7 +188,7 @@ describe Moab::FileInventory do
   end
 
   describe "#summary_fields" do
-    specify '#summary' do
+    it '#summary' do
       hash = parsed_file_inventory.summary
       expect(hash).to eq("type" => "version",
                          "digital_object_id" => "druid:jq937jp0017",
@@ -216,7 +216,7 @@ describe Moab::FileInventory do
           })
     end
 
-    specify '#to_json summary' do
+    it '#to_json summary' do
       json = parsed_file_inventory.to_json(true)
       expect("#{json}\n").to eq <<-JSON
 {

--- a/spec/unit_tests/moab/file_manifestation_spec.rb
+++ b/spec/unit_tests/moab/file_manifestation_spec.rb
@@ -18,12 +18,12 @@ describe Moab::FileManifestation do
   end
 
   describe '#initialize' do
-    specify 'empty options hash' do
+    it 'empty options hash' do
       file_manifestation = described_class.new({})
       expect(file_manifestation.instances).to be_instance_of Array
     end
 
-    specify 'options passed in' do
+    it 'options passed in' do
       opts = {
         signature: double(Moab::FileSignature.name),
         instances: double(Moab::FileInstance.name)
@@ -37,34 +37,34 @@ describe Moab::FileManifestation do
   describe '#signature' do
     let(:value) { double(Moab::FileSignature.name) }
 
-    specify 'single value' do
+    it 'single value' do
       file_manifestation.signature = value
       expect(file_manifestation.signature).to eq value
     end
 
-    specify 'becomes first value if set to Array of values' do
+    it 'becomes first value if set to Array of values' do
       file_manifestation.signature = [value]
       expect(file_manifestation.signature).to eq value
     end
   end
 
-  specify '#paths' do
+  it '#paths' do
     expect(file_manifestation.paths).to eq ["title.jpg", "page-1.jpg"]
   end
 
-  specify '#file_count' do
+  it '#file_count' do
     expect(file_manifestation.file_count).to eq 2
   end
 
-  specify '#byte_count' do
+  it '#byte_count' do
     expect(file_manifestation.byte_count).to eq 81746
   end
 
-  specify '#block_count' do
+  it '#block_count' do
     expect(file_manifestation.block_count).to eq 80
   end
 
-  specify '#==' do
+  it '#==' do
     other = file_manifestation
     expect(file_manifestation == other).to be true
   end

--- a/spec/unit_tests/moab/file_signature_spec.rb
+++ b/spec/unit_tests/moab/file_signature_spec.rb
@@ -48,7 +48,7 @@ describe Moab::FileSignature do
     end
   end
 
-  specify '#initialize' do
+  it '#initialize' do
     opts = {
       size: 75,
       md5: 'Test md5',
@@ -79,7 +79,7 @@ describe Moab::FileSignature do
     end
   end
 
-  specify '#fixity' do
+  it '#fixity' do
     expected_sig_fixity = {
       size: "40873",
       md5: "1a726cd7963bd6d3ceb10a8c353ec166",
@@ -89,7 +89,7 @@ describe Moab::FileSignature do
     expect(title_v1_signature.fixity).to eq expected_sig_fixity
   end
 
-  specify '#checksums' do
+  it '#checksums' do
     expected_checksums = {
       md5: "1a726cd7963bd6d3ceb10a8c353ec166",
       sha1: "583220e0572640abcd3ddd97393d224e8053a6ad",
@@ -98,23 +98,23 @@ describe Moab::FileSignature do
     expect(title_v1_signature.checksums).to eq expected_checksums
   end
 
-  specify '#eql?' do
+  it '#eql?' do
     expect(title_v1_signature.eql?(title_v2_signature)).to be true
     expect(page1_v1_signature.eql?(page1_v2_signature)).to be false
   end
 
-  specify '#==' do
+  it '#==' do
     expect(title_v1_signature == title_v2_signature).to be true
     expect(page1_v1_signature == page1_v2_signature).to be false
   end
 
-  specify '#hash' do
+  it '#hash' do
     expect(title_v1_signature.hash).to be_kind_of Numeric
     expect(title_v1_signature.hash == title_v2_signature.hash).to be true
     expect(page1_v1_signature.hash == page1_v2_signature.hash).to be false
   end
 
-  specify '#signature_from_file' do
+  it '#signature_from_file' do
     expect(title_v1_signature.size).to eq 40873
     expect(title_v1_signature.md5).to eq "1a726cd7963bd6d3ceb10a8c353ec166"
     expect(title_v1_signature.sha1).to eq "583220e0572640abcd3ddd97393d224e8053a6ad"
@@ -131,26 +131,26 @@ describe Moab::FileSignature do
       }
     end
 
-    specify 'when given all checksums' do
+    it 'when given all checksums' do
       fs = described_class.new(page2_fixity)
       signature = fs.normalized_signature(page2_v1_pathname)
       expect(signature.fixity).to eq(page2_fixity)
     end
 
-    specify 'when given partial checksums' do
+    it 'when given partial checksums' do
       fs = described_class.new(size: "39450", sha1: 'd0857baa307a2e9efff42467b5abd4e1cf40fcd5')
       signature = fs.normalized_signature(page2_v1_pathname)
       expect(signature.fixity).to eq(page2_fixity)
     end
 
-    specify 'when given bad checksum' do
+    it 'when given bad checksum' do
       fs = described_class.new(sha1: 'dummy')
       exp_err_regex = /Signature inconsistent between inventory and file/
       expect { fs.normalized_signature(page2_v1_pathname) }.to raise_exception(Moab::MoabRuntimeError, exp_err_regex)
     end
   end
 
-  specify '.checksum_names_for_type' do
+  it '.checksum_names_for_type' do
     expect(described_class.checksum_names_for_type).to eq(
       md5: ["MD5"],
       sha1: %w[SHA-1 SHA1],
@@ -158,7 +158,7 @@ describe Moab::FileSignature do
     )
   end
 
-  specify '.checksum_type_for_name' do
+  it '.checksum_type_for_name' do
     expect(described_class.checksum_type_for_name).to eq(
       "MD5" => :md5,
       "SHA1" => :sha1,

--- a/spec/unit_tests/moab/signature_catalog_entry_spec.rb
+++ b/spec/unit_tests/moab/signature_catalog_entry_spec.rb
@@ -3,7 +3,7 @@
 describe Moab::SignatureCatalogEntry do
   let(:sce) { described_class.new }
 
-  specify '#initialize' do
+  it '#initialize' do
     opts = {
       version_id: 26,
       group_id: 'Test group_id',
@@ -17,13 +17,13 @@ describe Moab::SignatureCatalogEntry do
     expect(signature_catalog_entry.signature).to eq(opts[:signature])
   end
 
-  specify '#signature becomes first value if set to Array' do
+  it '#signature becomes first value if set to Array' do
     value = double(Moab::FileSignature.name)
     sce.signature = [value, 'dummy']
     expect(sce.signature).to eq value
   end
 
-  specify '#storage_path' do
+  it '#storage_path' do
     sce.version_id = 5
     sce.group_id = 'content'
     sce.path = 'title.jpg'

--- a/spec/unit_tests/moab/signature_catalog_spec.rb
+++ b/spec/unit_tests/moab/signature_catalog_spec.rb
@@ -34,39 +34,39 @@ describe Moab::SignatureCatalog do
   end
 
   describe '.parse sets attributes' do
-    specify 'digital_object_id' do
+    it 'digital_object_id' do
       expect(@signature_catalog.digital_object_id).to eq('druid:jq937jp0017')
     end
 
-    specify 'version_id' do
+    it 'version_id' do
       expect(@signature_catalog.version_id).to eq(1)
     end
 
-    specify 'catalog_datetime' do
+    it 'catalog_datetime' do
       expect(Time.parse(@signature_catalog.catalog_datetime)).to be_instance_of(Time)
     end
 
-    specify 'file_count' do
+    it 'file_count' do
       expect(@signature_catalog.file_count).to eq(11)
     end
 
-    specify 'byte_count' do
+    it 'byte_count' do
       expect(@signature_catalog.byte_count).to eq(217820)
     end
 
-    specify 'block_count' do
+    it 'block_count' do
       expect(@signature_catalog.block_count).to eq(216)
     end
 
-    specify 'entries' do
+    it 'entries' do
       expect(@signature_catalog.entries.size).to eq(11)
     end
 
-    specify 'signature_hash' do
+    it 'signature_hash' do
       expect(@signature_catalog.signature_hash.size).to eq(11)
     end
 
-    specify 'composite_key' do
+    it 'composite_key' do
       expect(@signature_catalog.composite_key).to eq("druid:jq937jp0017-v0001")
     end
   end
@@ -79,14 +79,14 @@ describe Moab::SignatureCatalog do
     end
   end
 
-  specify '#add_entry' do
+  it '#add_entry' do
     entry = double(Moab::SignatureCatalogEntry.name)
     expect(entry).to receive(:signature).and_return(double(Moab::FileSignature.name))
     @signature_catalog.add_entry(entry)
     expect(@signature_catalog.entries.count).to eq(@original_entry_count + 1)
   end
 
-  specify '#catalog_filepath' do
+  it '#catalog_filepath' do
     file_signature = @signature_catalog.entries[0].signature
     filepath = @signature_catalog.catalog_filepath(file_signature)
     expect(filepath).to eq('v0001/data/content/intro-1.jpg')
@@ -94,7 +94,7 @@ describe Moab::SignatureCatalog do
     expect { @signature_catalog.catalog_filepath(file_signature) }.to raise_exception Moab::FileNotFoundException
   end
 
-  specify '#normalize_group_signatures' do
+  it '#normalize_group_signatures' do
     @v2_inventory.groups.each do |group|
       group.data_source = @v2_inventory_pathname.parent.parent.join('data', group.group_id).to_s
       if group.group_id == 'content'
@@ -117,7 +117,7 @@ describe Moab::SignatureCatalog do
     )
   end
 
-  specify '#update' do
+  it '#update' do
     @v2_inventory.groups.each do |group|
       if group.group_id == 'metadata'
         group.files.each do |file|
@@ -136,7 +136,7 @@ describe Moab::SignatureCatalog do
     )
   end
 
-  specify '#version_additions' do
+  it '#version_additions' do
     version_additions = @signature_catalog.version_additions(@v2_inventory)
     expect(version_additions.groups.count).to eq(2)
     expect(version_additions.file_count).to eq(4)
@@ -144,7 +144,7 @@ describe Moab::SignatureCatalog do
     expect(version_additions.block_count).to eq(37)
   end
 
-  specify "#summary has fields set in #summary_fields" do
+  it "#summary has fields set in #summary_fields" do
     expect(@signature_catalog.summary).to eq("digital_object_id" => "druid:jq937jp0017",
                                              "version_id" => 1,
                                              "catalog_datetime" => @signature_catalog.catalog_datetime.to_s,
@@ -153,7 +153,7 @@ describe Moab::SignatureCatalog do
                                              "block_count" => 216)
   end
 
-  specify "Serialization to string using HappyMapper to_xml" do
+  it "Serialization to string using HappyMapper to_xml" do
     expect(@signature_catalog.to_xml).to match(/.*<\/signatureCatalog>$/)
   end
 end

--- a/spec/unit_tests/moab/storage_object_spec.rb
+++ b/spec/unit_tests/moab/storage_object_spec.rb
@@ -20,7 +20,7 @@ describe Moab::StorageObject do
     @ingest_object_dir = ingests_dir.join(BARE_TEST_DRUID)
   end
 
-  specify '.version_dirname' do
+  it '.version_dirname' do
     expect(described_class.version_dirname(1)).to eq "v0001"
     expect(described_class.version_dirname(22)).to eq "v0022"
     expect(described_class.version_dirname(333)).to eq "v0333"
@@ -28,13 +28,13 @@ describe Moab::StorageObject do
     expect(described_class.version_dirname(55555)).to eq "v55555"
   end
 
-  specify '#initialize' do
+  it '#initialize' do
     storage_object = described_class.new(FULL_TEST_DRUID, @temp_object_dir)
     expect(storage_object.digital_object_id).to eq FULL_TEST_DRUID
     expect(storage_object.object_pathname.to_s).to include('temp/ingests/jq937jp0017')
   end
 
-  specify '#initialize_storage' do
+  it '#initialize_storage' do
     @temp_object_dir.rmtree if @temp_object_dir.exist?
     expect(@temp_object_dir.exist?).to be false
     expect(@storage_object.exist?).to be false
@@ -43,11 +43,11 @@ describe Moab::StorageObject do
     expect(@storage_object.exist?).to be true
   end
 
-  specify '#deposit_home' do
+  it '#deposit_home' do
     expect(@storage_object.deposit_home).to eq(packages_dir)
   end
 
-  specify '#deposit_bag_pathname' do
+  it '#deposit_bag_pathname' do
     expect(@storage_object.deposit_bag_pathname).to eq(packages_dir.join('jq937jp0017'))
   end
 
@@ -213,7 +213,7 @@ describe Moab::StorageObject do
     end
   end
 
-  specify '#versionize_bag' do
+  it '#versionize_bag' do
     bag_dir = temp_dir.join('plain_bag')
     bag_dir.rmtree if bag_dir.exist?
     FileUtils.cp_r(packages_dir.join(TEST_OBJECT_VERSIONS[1]).to_s, bag_dir.to_s, preserve: true)
@@ -452,29 +452,29 @@ describe Moab::StorageObject do
     end
   end
 
-  specify '#version_id_list' do
+  it '#version_id_list' do
     expect(@storage_object.version_id_list.size).to eq 0
     expect(storage_object.version_id_list.size).to eq 3
   end
 
-  specify '#version_list' do
+  it '#version_list' do
     expect(@storage_object.version_list.size).to eq 0
     version_list = storage_object.version_list
     expect(version_list.size).to eq 3
     expect(version_list[1].version_id).to eq 2
   end
 
-  specify '#current_version_id' do
+  it '#current_version_id' do
     expect(@storage_object.current_version_id).to eq 0
     expect(storage_object.current_version_id).to eq 3
   end
 
-  specify '#current_version' do
+  it '#current_version' do
     expect(@storage_object.current_version.version_id).to eq 0
     expect(storage_object.current_version.version_id).to eq 3
   end
 
-  specify '#validate_new_inventory' do
+  it '#validate_new_inventory' do
     version_inventory_3 = double("#{Moab::FileInventory.name}3")
     expect(version_inventory_3).to receive(:version_id).twice.and_return 3
     exp_regex = /version mismatch/
@@ -532,11 +532,11 @@ describe Moab::StorageObject do
     end
   end
 
-  specify '#verify_object_storage' do
+  it '#verify_object_storage' do
     expect(storage_object.verify_object_storage.verified).to be true
   end
 
-  specify '#restore_object' do
+  it '#restore_object' do
     expect(@storage_object.version_list.size).to eq 0
     @storage_object.restore_object(@ingest_object_dir)
     expect(@storage_object.version_list.size).to eq 3

--- a/spec/unit_tests/moab/storage_object_version_spec.rb
+++ b/spec/unit_tests/moab/storage_object_version_spec.rb
@@ -46,7 +46,7 @@ describe Moab::StorageObjectVersion do
     end
   end
 
-  specify '#composite_key' do
+  it '#composite_key' do
     expect(@existing_storage_object_version.composite_key).to eq("druid:jq937jp0017-v0002")
   end
 
@@ -109,7 +109,7 @@ describe Moab::StorageObjectVersion do
     end
   end
 
-  specify '#find_filepath_using_signature' do
+  it '#find_filepath_using_signature' do
     fixity_hash = {
       size: 40873,
       md5: "1a726cd7963bd6d3ceb10a8c353ec166",
@@ -153,12 +153,12 @@ describe Moab::StorageObjectVersion do
     end
   end
 
-  specify '#file_inventory' do
+  it '#file_inventory' do
     # TODO: test all allowed type values and disallowed type value, version_id = 0
     expect(@existing_storage_object_version.file_inventory('version')).to be_an_instance_of(Moab::FileInventory)
   end
 
-  specify '#signature_catalog' do
+  it '#signature_catalog' do
     # TODO: write better test
     expect(@existing_storage_object_version.signature_catalog).to be_instance_of(Moab::SignatureCatalog)
   end
@@ -231,7 +231,7 @@ describe Moab::StorageObjectVersion do
     end
   end
 
-  specify '#ingest_dir' do
+  it '#ingest_dir' do
     source_dir = packages_dir.join("v0001/data")
     temp_storage_object_version = described_class.new(@temp_storage_object, 1)
     target_dir = temp_storage_object_version.version_pathname.join('data')
@@ -292,7 +292,7 @@ describe Moab::StorageObjectVersion do
     end
   end
 
-  specify '#update_catalog' do
+  it '#update_catalog' do
     temp_storage_object_version = described_class.new(@temp_storage_object, 4)
     signature_catalog = double(Moab::SignatureCatalog.name)
     new_inventory = double(Moab::FileInventory.name)
@@ -302,7 +302,7 @@ describe Moab::StorageObjectVersion do
     temp_storage_object_version.update_catalog(signature_catalog, new_inventory)
   end
 
-  specify '#generate_differences_report' do
+  it '#generate_differences_report' do
     old_inventory = double(Moab::FileInventory.name)
     new_inventory = double(Moab::FileInventory.name)
     mock_fid = double(Moab::FileInventoryDifference.name)
@@ -313,7 +313,7 @@ describe Moab::StorageObjectVersion do
     @existing_storage_object_version.generate_differences_report(old_inventory, new_inventory)
   end
 
-  specify '#generate_manifest_inventory' do
+  it '#generate_manifest_inventory' do
     temp_storage_object_version = described_class.new(@temp_storage_object, 2)
     temp_version_pathname = temp_storage_object_version.version_pathname
     temp_version_pathname.mkpath
@@ -326,7 +326,7 @@ describe Moab::StorageObjectVersion do
     expect(Moab::FileInventory.xml_pathname_exist?(temp_version_pathname.join('manifests'), 'manifests')).to be true
   end
 
-  specify '#verify_version_storage' do
+  it '#verify_version_storage' do
     result = @existing_storage_object_version.verify_version_storage
     expect(result.verified).to be true
   end
@@ -572,7 +572,7 @@ describe Moab::StorageObjectVersion do
     end
   end
 
-  specify '#deactivate' do
+  it '#deactivate' do
     # create an object version in a temp location by copying from ingests location
     @temp_object_dir.mkpath
     version_id = @existing_storage_object_version.version_id

--- a/spec/unit_tests/moab/storage_repository_spec.rb
+++ b/spec/unit_tests/moab/storage_repository_spec.rb
@@ -6,28 +6,28 @@ describe Moab::StorageRepository do
   let(:derivatives2_storage_root) { fixtures_dir.join('derivatives2') }
   let(:newnode_storage_root) { fixtures_dir.join('newnode') }
 
-  specify '#storage_roots' do
+  it '#storage_roots' do
     # these are set in spec_config.rb
     expect(storage_repo.storage_roots[0]).to eq derivatives_storage_root
     expect(storage_repo.storage_roots[1]).to eq derivatives2_storage_root
     expect(storage_repo.storage_roots[2]).to eq newnode_storage_root
   end
 
-  specify '#storage_trunk' do
+  it '#storage_trunk' do
     # set in spec_config.rb
     expect(storage_repo.storage_trunk).to eq 'ingests'
   end
 
-  specify '#deposit_trunk' do
+  it '#deposit_trunk' do
     # set in spec_config.rb
     expect(storage_repo.deposit_trunk).to eq 'packages'
   end
 
-  specify '#storage_branch' do
+  it '#storage_branch' do
     expect(storage_repo.storage_branch('abcdef')).to eq 'ab/cd/ef/abcdef'
   end
 
-  specify '#deposit_branch' do
+  it '#deposit_branch' do
     expect(storage_repo.deposit_branch('abcdef')).to eq 'abcdef'
   end
 
@@ -71,7 +71,7 @@ describe Moab::StorageRepository do
     end
   end
 
-  specify '#find_storage_object' do
+  it '#find_storage_object' do
     allow(storage_repo).to receive(:storage_branch).and_return('jq937jp0017')
     found_storage_obj = storage_repo.find_storage_object('jq937jp0017')
     expect(found_storage_obj.object_pathname).to eq derivatives_storage_root.join('ingests/jq937jp0017')
@@ -105,13 +105,15 @@ describe Moab::StorageRepository do
     expect(storage_repo.object_size('jq937jp0017')).to be_between(345_000, 346_000)
   end
 
-  specify "#store_new_object_version" do
-    bag_pathname = double("bag_pathname")
-    object_pathname = double("object_pathname")
-    storage_object = double(Moab::StorageObject)
-    expect(storage_repo).to receive(:storage_object).with(FULL_TEST_DRUID, true).and_return(storage_object)
-    allow(storage_object).to receive(:object_pathname).and_return(object_pathname)
-    expect(storage_object).to receive(:ingest_bag).with(bag_pathname)
-    storage_repo.store_new_object_version(FULL_TEST_DRUID, bag_pathname)
+  describe '#store_new_object_version' do
+    it 'calls storage_object and ingest_bag' do
+      bag_pathname = double("bag_pathname")
+      object_pathname = double("object_pathname")
+      storage_object = double(Moab::StorageObject)
+      expect(storage_repo).to receive(:storage_object).with(FULL_TEST_DRUID, true).and_return(storage_object)
+      allow(storage_object).to receive(:object_pathname).and_return(object_pathname)
+      expect(storage_object).to receive(:ingest_bag).with(bag_pathname)
+      storage_repo.store_new_object_version(FULL_TEST_DRUID, bag_pathname)
+    end
   end
 end

--- a/spec/unit_tests/moab/storage_services_spec.rb
+++ b/spec/unit_tests/moab/storage_services_spec.rb
@@ -13,17 +13,17 @@ describe Moab::StorageServices do
     expect(threads.map(&:value).uniq.size).to eq(1)
   end
 
-  specify '.storage_roots' do
+  it '.storage_roots' do
     expect(described_class.storage_roots).to eq([fixtures_dir.join('derivatives'),
                                                  fixtures_dir.join('derivatives2'),
                                                  fixtures_dir.join('newnode')])
   end
 
-  specify '.deposit_trunk' do
+  it '.deposit_trunk' do
     expect(described_class.deposit_trunk).to eq 'packages'
   end
 
-  specify '.deposit_branch' do
+  it '.deposit_branch' do
     expect(described_class.deposit_branch(BARE_TEST_DRUID)).to eq 'jq937jp0017'
   end
 
@@ -63,21 +63,21 @@ describe Moab::StorageServices do
     end
   end
 
-  specify '.object_path' do
+  it '.object_path' do
     expect(described_class.object_path(BARE_TEST_DRUID)).to match('spec/fixtures/derivatives/ingests/jq937jp0017')
   end
 
-  specify '.object_version_path' do
+  it '.object_version_path' do
     expect(described_class.object_version_path(BARE_TEST_DRUID, 1)).to match(
       'spec/fixtures/derivatives/ingests/jq937jp0017/v0001'
     )
   end
 
-  specify '.current_version' do
+  it '.current_version' do
     expect(described_class.current_version(BARE_TEST_DRUID)).to eq 3
   end
 
-  specify '.object_size' do
+  it '.object_size' do
     expect(described_class.object_size(BARE_TEST_DRUID)).to be_between(340000, 350000)
   end
 
@@ -121,7 +121,7 @@ describe Moab::StorageServices do
     end
   end
 
-  specify '.retrieve_file_using_signature' do
+  it '.retrieve_file_using_signature' do
     fixity_hash = {
       size: "40873",
       md5: "1a726cd7963bd6d3ceb10a8c353ec166",
@@ -162,7 +162,7 @@ describe Moab::StorageServices do
     end
   end
 
-  specify '.version_differences' do
+  it '.version_differences' do
     differences = described_class.version_differences(BARE_TEST_DRUID, 2, 3)
     diff_ng_xml = Nokogiri::XML(differences.to_xml)
     diff_ng_xml.xpath('//@reportDatetime').remove

--- a/spec/unit_tests/moab/verification_result_spec.rb
+++ b/spec/unit_tests/moab/verification_result_spec.rb
@@ -19,7 +19,7 @@ describe Moab::VerificationResult do
     result
   end
 
-  specify '.verify_value' do
+  it '.verify_value' do
     result = described_class.verify_value('greeting', "hello", "goodbye")
     expect(result.entity).to eq 'greeting'
     expect(result.verified).to be false
@@ -28,7 +28,7 @@ describe Moab::VerificationResult do
     expect(result.subentities.size).to eq 0
   end
 
-  specify '.verify_truth' do
+  it '.verify_truth' do
     result = described_class.verify_truth('truth', "true")
     expect(result.entity).to eq 'truth'
     expect(result.verified).to be true
@@ -37,7 +37,7 @@ describe Moab::VerificationResult do
     expect(result.subentities.size).to eq 0
   end
 
-  specify '#initialize' do
+  it '#initialize' do
     result = described_class.new('my_entity')
     expect(result.entity).to eq 'my_entity'
     expect(result.verified).to be false
@@ -45,7 +45,7 @@ describe Moab::VerificationResult do
     expect(result.subentities).to be_an_instance_of Array
   end
 
-  specify '#to_hash' do
+  it '#to_hash' do
     detail_hash = result.to_hash(true)
     expect("#{JSON.pretty_generate(detail_hash)}\n").to eq <<-JSON
 {

--- a/spec/unit_tests/serializer/manifest_spec.rb
+++ b/spec/unit_tests/serializer/manifest_spec.rb
@@ -23,12 +23,12 @@ describe Serializer::Manifest do
     end
   end
 
-  specify '.xml_pathname_exist?' do
+  it '.xml_pathname_exist?' do
     expect(described_class.xml_pathname_exist?("/test/parent_dir", "dummy")).to be(false)
     expect(Moab::SignatureCatalog.xml_pathname_exist?(manifests_dir.join("v0001"))).to be(true)
   end
 
-  specify '.read_xml_file' do
+  it '.read_xml_file' do
     parent_dir = manifests_dir.join("v1")
     mock_pathname = double(Pathname.name)
     mock_xml = double("xml")
@@ -38,7 +38,7 @@ describe Serializer::Manifest do
     Moab::SignatureCatalog.read_xml_file(parent_dir)
   end
 
-  specify '.write_xml_file' do
+  it '.write_xml_file' do
     xml_object = Moab::SignatureCatalog.read_xml_file(manifests_dir.join("v0001"))
     #xml_object.should_receive(:to_xml)
     output_dir = temp_dir

--- a/spec/unit_tests/serializer/serializable_spec.rb
+++ b/spec/unit_tests/serializer/serializable_spec.rb
@@ -146,7 +146,7 @@ describe Serializer::Serializable do
     end
   end
 
-  specify '#array_to_hash' do
+  it '#array_to_hash' do
     array = %w[this is an array of words]
     expect(described_class.new.array_to_hash(array)).to hash_match(0 => "this",
                                                                    1 => "is",
@@ -156,7 +156,7 @@ describe Serializer::Serializable do
                                                                    5 => "words")
   end
 
-  specify '#to_hash' do
+  it '#to_hash' do
     additions = Moab::FileInventory.read_xml_file(manifests_dir.join("v0002"), 'additions')
     hash = additions.groups[0].to_hash
     hash['files'][0].delete('instances')
@@ -212,7 +212,7 @@ describe Serializer::Serializable do
     end
   end
 
-  specify '#to_json' do
+  it '#to_json' do
     adj_v1_content = @v1_content.to_json
                                 .gsub(/"datetime": ".*?"/, '"datetime": ""')
                                 .gsub(/: ".*moab-versioning/, ': "moab-versioning')

--- a/spec/unit_tests/stanford/content_inventory_spec.rb
+++ b/spec/unit_tests/stanford/content_inventory_spec.rb
@@ -98,7 +98,7 @@ describe Stanford::ContentInventory do
   end
 
   # testing boundary case where all subset attributes are no (e.g. shelve='no')
-  specify '#inventory_from_cm with empty subset' do
+  it '#inventory_from_cm with empty subset' do
     %w[shelve publish preserve].each do |subset|
       inventory = @content_inventory.inventory_from_cm(content_metadata_empty_subset, 'druid:ms205ty4764', subset, 1)
       inventory_ng_xml = Nokogiri::XML(inventory.to_xml)
@@ -169,12 +169,12 @@ describe Stanford::ContentInventory do
     end
   end
 
-  specify '#generate_instance' do
+  it '#generate_instance' do
     expect(@content_inventory.generate_instance(@node)).to hash_match("path" => "title.jpg",
                                                                       "datetime" => "2012-03-26T14:15:11Z")
   end
 
-  specify '#generate_content_metadata' do
+  it '#generate_content_metadata' do
     directory = data_dir.join('v0002/content')
     group = Moab::FileGroup.new.group_from_directory(directory, true)
     cm = @content_inventory.generate_content_metadata(group, BARE_TEST_DRUID, 2)

--- a/spec/unit_tests/stanford/storage_services_spec.rb
+++ b/spec/unit_tests/stanford/storage_services_spec.rb
@@ -14,7 +14,7 @@ describe Stanford::StorageServices do
     expect(threads.map(&:value).uniq.size).to eq(1)
   end
 
-  specify '.cm_remediate' do
+  it '.cm_remediate' do
     remediated_cm = described_class.cm_remediate(BARE_TEST_DRUID, 1)
     remediated_cm_ng_xml = Nokogiri::XML(remediated_cm)
     exp_xml = <<-XML


### PR DESCRIPTION
## Why was this change made? 🤔

"specify" is very old rspec.  Part of #194.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to filesystem, or what is expected to be read from filesystem), run ***[integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** on stage as it tests preservation, and/or test in stage environment, in addition to specs.⚡


