### PR TITLE
use spec_helper constants for test druid

### DIFF
--- a/spec/features/differences/version_compare_spec.rb
+++ b/spec/features/differences/version_compare_spec.rb
@@ -25,6 +25,6 @@ describe 'Compare versions' do
     expect(diff.basis).to eq('v1')
     expect(diff.other).to eq('v2')
     expect(diff.difference_count).to eq(6)
-    expect(diff.digital_object_id).to eq('druid:jq937jp0017')
+    expect(diff.digital_object_id).to eq(FULL_TEST_DRUID)
   end
 end

--- a/spec/unit_tests/moab/file_group_difference_spec.rb
+++ b/spec/unit_tests/moab/file_group_difference_spec.rb
@@ -382,7 +382,7 @@ describe Moab::FileGroupDifference do
   end
 
   it '.parse' do
-    fixture = ingests_dir.join('jq937jp0017', 'v0003', 'manifests', 'fileInventoryDifference.xml')
+    fixture = ingests_dir.join(BARE_TEST_DRUID, 'v0003', 'manifests', 'fileInventoryDifference.xml')
     fid = Moab::FileInventoryDifference.parse(File.read(fixture))
     fgd = fid.group_difference('content')
     expect(fgd.subsets.count).to be >= 5

--- a/spec/unit_tests/moab/file_inventory_difference_spec.rb
+++ b/spec/unit_tests/moab/file_inventory_difference_spec.rb
@@ -42,7 +42,7 @@ describe Moab::FileInventoryDifference do
 
     describe 'attributes set' do
       it '#digital_object_id' do
-        expect(diff_v1_v2.digital_object_id).to eq 'druid:jq937jp0017'
+        expect(diff_v1_v2.digital_object_id).to eq FULL_TEST_DRUID
       end
 
       it '#difference_count' do
@@ -94,14 +94,14 @@ describe Moab::FileInventoryDifference do
     end
 
     it 'same id' do
-      expect(new_diff.common_object_id(v1_inventory, v2_inventory)).to eq 'druid:jq937jp0017'
+      expect(new_diff.common_object_id(v1_inventory, v2_inventory)).to eq FULL_TEST_DRUID
     end
   end
 
   it '#summary_fields' do
     hash = diff_v1_v2.summary
     hash.delete('report_datetime')
-    expect(hash).to eq('digital_object_id' => 'druid:jq937jp0017',
+    expect(hash).to eq('digital_object_id' => FULL_TEST_DRUID,
                        'basis' => 'v1',
                        'other' => 'v2',
                        'difference_count' => 6,

--- a/spec/unit_tests/moab/file_inventory_spec.rb
+++ b/spec/unit_tests/moab/file_inventory_spec.rb
@@ -58,7 +58,7 @@ describe Moab::FileInventory do
     end
 
     it '#digital_object_id' do
-      expect(parsed_file_inventory.digital_object_id).to eq 'druid:jq937jp0017'
+      expect(parsed_file_inventory.digital_object_id).to eq FULL_TEST_DRUID
     end
 
     it '#version_id' do
@@ -191,7 +191,7 @@ describe Moab::FileInventory do
     it '#summary' do
       hash = parsed_file_inventory.summary
       expect(hash).to eq('type' => 'version',
-                         'digital_object_id' => 'druid:jq937jp0017',
+                         'digital_object_id' => FULL_TEST_DRUID,
                          'version_id' => 1,
                          'file_count' => 11,
                          'byte_count' => 217820,

--- a/spec/unit_tests/moab/signature_catalog_spec.rb
+++ b/spec/unit_tests/moab/signature_catalog_spec.rb
@@ -38,7 +38,7 @@ describe Moab::SignatureCatalog do
 
   describe '.parse (from HappyMapper XML to object mapping library)' do
     it 'digital_object_id assigned' do
-      expect(signature_catalog.digital_object_id).to eq('druid:jq937jp0017')
+      expect(signature_catalog.digital_object_id).to eq(FULL_TEST_DRUID)
     end
 
     it 'version_id assigned' do
@@ -186,7 +186,7 @@ describe Moab::SignatureCatalog do
 
   describe '#summary' do
     it 'returns hash of summary fields with values' do
-      expect(signature_catalog.summary).to eq('digital_object_id' => 'druid:jq937jp0017',
+      expect(signature_catalog.summary).to eq('digital_object_id' => FULL_TEST_DRUID,
                                               'version_id' => 1,
                                               'catalog_datetime' => signature_catalog.catalog_datetime.to_s,
                                               'file_count' => 11,

--- a/spec/unit_tests/moab/storage_object_version_spec.rb
+++ b/spec/unit_tests/moab/storage_object_version_spec.rb
@@ -134,7 +134,7 @@ describe Moab::StorageObjectVersion do
 
     it 'finds expected path' do
       storage_object_path = existing_storage_object_version.find_filepath_using_signature('content', file_signature).to_s
-      expected_path = File.join('ingests', 'jq937jp0017', 'v0001', 'data', 'content', 'title.jpg')
+      expected_path = File.join('ingests', BARE_TEST_DRUID, 'v0001', 'data', 'content', 'title.jpg')
       expect(storage_object_path).to include expected_path
     end
   end
@@ -159,7 +159,7 @@ describe Moab::StorageObjectVersion do
   end
 
   describe '#file_category_pathname' do
-    let(:data_path) { File.join('derivatives', 'ingests', 'jq937jp0017', 'v0002') }
+    let(:data_path) { File.join('derivatives', 'ingests', BARE_TEST_DRUID, 'v0002') }
     let(:content_path) { File.join(data_path, 'data', 'content') }
     let(:metadata_path) { File.join(data_path, 'data', 'metadata') }
     let(:manifests_path) { File.join(data_path, 'manifests') }

--- a/spec/unit_tests/moab/storage_services_spec.rb
+++ b/spec/unit_tests/moab/storage_services_spec.rb
@@ -24,7 +24,7 @@ describe Moab::StorageServices do
   end
 
   it '.deposit_branch' do
-    expect(described_class.deposit_branch(BARE_TEST_DRUID)).to eq 'jq937jp0017'
+    expect(described_class.deposit_branch(BARE_TEST_DRUID)).to eq BARE_TEST_DRUID
   end
 
   describe '.find_storage_object' do

--- a/spec/unit_tests/stanford/content_inventory_spec.rb
+++ b/spec/unit_tests/stanford/content_inventory_spec.rb
@@ -212,7 +212,7 @@ describe Stanford::ContentInventory do
 
   describe '#validate_content_metadata' do
     it 'returns true when valid data' do
-      cm = fixtures_dir.join('data', 'jq937jp0017', 'v0001', 'metadata', 'contentMetadata.xml').read
+      cm = fixtures_dir.join('data', BARE_TEST_DRUID, 'v0001', 'metadata', 'contentMetadata.xml').read
       expect(@content_inventory.validate_content_metadata(cm)).to be(true)
     end
 

--- a/spec/unit_tests/stanford/storage_repository_spec.rb
+++ b/spec/unit_tests/stanford/storage_repository_spec.rb
@@ -15,7 +15,7 @@ describe Stanford::StorageRepository do
       Moab::Config.configure do
         path_method :druid
       end
-      expect(storage_repository.storage_branch(FULL_TEST_DRUID).to_s).to eq('jq937jp0017')
+      expect(storage_repository.storage_branch(FULL_TEST_DRUID).to_s).to eq(BARE_TEST_DRUID)
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Let's call it what it is:  OCD.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to filesystem, or what is expected to be read from filesystem), run ***[integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** on stage as it tests preservation, and/or test in stage environment, in addition to specs.⚡


