### PR TITLE
storage_repository_spec: update to current rspec conventions

### DIFF
--- a/lib/moab/storage_repository.rb
+++ b/lib/moab/storage_repository.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'find' # for object_size
+
 module Moab
   # A class to represent the SDR repository store
   #

--- a/spec/unit_tests/moab/storage_repository_spec.rb
+++ b/spec/unit_tests/moab/storage_repository_spec.rb
@@ -2,48 +2,70 @@
 
 describe Moab::StorageRepository do
   let(:storage_repo) { described_class.new }
-  let(:derivatives_storage_root) { fixtures_dir.join('derivatives') }
+  let(:derivatives_storage_root) { derivatives_dir }
   let(:derivatives2_storage_root) { fixtures_dir.join('derivatives2') }
   let(:newnode_storage_root) { fixtures_dir.join('newnode') }
 
-  it '#storage_roots' do
-    # these are set in spec_config.rb
-    expect(storage_repo.storage_roots[0]).to eq derivatives_storage_root
-    expect(storage_repo.storage_roots[1]).to eq derivatives2_storage_root
-    expect(storage_repo.storage_roots[2]).to eq newnode_storage_root
+  describe '#storage_roots' do
+    it 'returns the configured values' do
+      # these are set in spec_config.rb
+      expect(storage_repo.storage_roots[0]).to eq derivatives_storage_root
+      expect(storage_repo.storage_roots[1]).to eq derivatives2_storage_root
+      expect(storage_repo.storage_roots[2]).to eq newnode_storage_root
+    end
   end
 
-  it '#storage_trunk' do
-    # set in spec_config.rb
-    expect(storage_repo.storage_trunk).to eq 'ingests'
+  describe '#storage_trunk' do
+    it 'returns the configured values' do
+      # set in spec_config.rb
+      expect(storage_repo.storage_trunk).to eq 'ingests'
+    end
   end
 
-  it '#deposit_trunk' do
-    # set in spec_config.rb
-    expect(storage_repo.deposit_trunk).to eq 'packages'
+  describe '#deposit_trunk' do
+    it 'returns the configured values' do
+      # set in spec_config.rb
+      expect(storage_repo.deposit_trunk).to eq 'packages'
+    end
   end
 
-  it '#storage_branch' do
-    expect(storage_repo.storage_branch('abcdef')).to eq 'ab/cd/ef/abcdef'
+  describe '#storage_branch' do
+    it 'splits the argument into 2-character segments, followed by a copy of the argument, if not overridden in subclass' do
+      expect(storage_repo.storage_branch('abcdef')).to eq 'ab/cd/ef/abcdef'
+    end
   end
 
-  it '#deposit_branch' do
-    expect(storage_repo.deposit_branch('abcdef')).to eq 'abcdef'
+  describe '#deposit_branch' do
+    it 'returns the argument as is, if not overridden in subclass' do
+      expect(storage_repo.deposit_branch('abcdef')).to eq 'abcdef'
+    end
   end
 
   describe '#find_storage_root' do
-    it 'new objects will be stored in the newest (most empty) filesystem' do
-      expect(storage_repo.find_storage_root('abcdef')).to eq newnode_storage_root
+    context 'with new object' do
+      it 'returns the newest/last (most empty) filesystem' do
+        expect(storage_repo.find_storage_root('abcdef')).to eq newnode_storage_root
+      end
     end
 
-    it 'object with known storage branch' do
-      allow(storage_repo).to receive(:storage_branch).and_return('jq937jp0017')
-      expect(storage_repo.find_storage_root('jq937jp0017')).to eq derivatives_storage_root
+    context 'with existing object' do
+      before do
+        allow(storage_repo).to receive(:storage_branch).and_return(BARE_TEST_DRUID)
+      end
+
+      it 'returns the storage root containing the object' do
+        expect(storage_repo.find_storage_root(BARE_TEST_DRUID)).to eq derivatives_storage_root
+      end
     end
 
-    it 'exception raised when storage_trunk is bogus' do
-      allow(storage_repo).to receive(:storage_trunk).and_return('junk')
-      expect { storage_repo.find_storage_root('abcdef') }.to raise_exception(Moab::MoabRuntimeError, /Storage area not found/)
+    context 'with misconfigured storage_trunk' do
+      before do
+        allow(storage_repo).to receive(:storage_trunk).and_return('junk')
+      end
+
+      it 'raises exception when storage_trunk does not exist' do
+        expect { storage_repo.find_storage_root('abcdef') }.to raise_exception(Moab::MoabRuntimeError, /Storage area not found/)
+      end
     end
   end
 
@@ -56,8 +78,8 @@ describe Moab::StorageRepository do
 
     context 'with existing storage objects' do
       it 'finds objects with known storage branches' do
-        allow(storage_repo).to receive(:storage_branch).and_return('jq937jp0017')
-        found_storage_objs = storage_repo.search_storage_objects('jq937jp0017')
+        allow(storage_repo).to receive(:storage_branch).and_return(BARE_TEST_DRUID)
+        found_storage_objs = storage_repo.search_storage_objects(BARE_TEST_DRUID)
         expect(found_storage_objs.length).to eq 2
         expect(found_storage_objs[0].object_pathname).to eq derivatives_storage_root.join('ingests/jq937jp0017')
         expect(found_storage_objs[1].object_pathname).to eq derivatives2_storage_root.join('ingests/jq937jp0017')
@@ -66,52 +88,73 @@ describe Moab::StorageRepository do
 
     it 'exception raised when storage_trunk is bogus' do
       allow(storage_repo).to receive(:storage_trunk).and_return('junk')
-      expect { storage_repo.search_storage_objects('abcdef') }.to raise_exception(Moab::MoabRuntimeError,
-                                                                                  /Storage area not found/)
+      expect do
+        storage_repo.search_storage_objects('abcdef')
+      end.to raise_exception(Moab::MoabRuntimeError, /Storage area not found/)
     end
   end
 
-  it '#find_storage_object' do
-    allow(storage_repo).to receive(:storage_branch).and_return('jq937jp0017')
-    found_storage_obj = storage_repo.find_storage_object('jq937jp0017')
-    expect(found_storage_obj.object_pathname).to eq derivatives_storage_root.join('ingests/jq937jp0017')
-    expect(found_storage_obj.deposit_bag_pathname).to eq derivatives_storage_root.join('packages/jq937jp0017')
+  describe '#find_storage_object' do
+    context 'when storage object exists' do
+      let(:found_storage_obj) { storage_repo.find_storage_object(BARE_TEST_DRUID) }
+
+      before do
+        allow(storage_repo).to receive(:storage_branch).and_return(BARE_TEST_DRUID)
+      end
+
+      it 'returns storage object populated as expected' do
+        expect(found_storage_obj.object_pathname).to eq derivatives_storage_root.join('ingests/jq937jp0017')
+        expect(found_storage_obj.deposit_bag_pathname).to eq derivatives_storage_root.join('packages/jq937jp0017')
+      end
+    end
   end
 
   describe '#storage_object' do
+    let(:mock_path) { double(Pathname) }
+    let(:mock_storage_obj) { double(Moab::StorageObject) }
+
     before do
-      mock_storage_obj = double(Moab::StorageObject)
       allow(storage_repo).to receive(:find_storage_object).and_return(mock_storage_obj)
-      @mock_path = double(Pathname)
-      allow(mock_storage_obj).to receive(:object_pathname).and_return(@mock_path)
-      allow(@mock_path).to receive(:exist?).and_return(false)
+      allow(mock_storage_obj).to receive(:object_pathname).and_return(mock_path)
+      allow(mock_path).to receive(:exist?).and_return(false)
     end
 
     it 'raises exception when object not found' do
-      expect { storage_repo.storage_object('jq937jp0017') }.to raise_exception(Moab::ObjectNotFoundException)
+      expect { storage_repo.storage_object(BARE_TEST_DRUID) }.to raise_exception(Moab::ObjectNotFoundException)
     end
 
     it 'creates path when create set to true' do
-      expect(@mock_path).to receive(:mkpath)
-      storage_repo.storage_object('jq937jp0017', true)
+      expect(mock_path).to receive(:mkpath)
+      storage_repo.storage_object(BARE_TEST_DRUID, true)
     end
   end
 
-  it '#object_size returns the size of a moab object' do
-    # values may differ from file system to file system (which is to be expected).
-    # if this test fails on your mac, make sure you don't have any extraneous .DS_Store files
-    # lingering in the fixture directories.
-    allow(storage_repo).to receive(:storage_branch).and_return('jq937jp0017')
-    expect(storage_repo.object_size('jq937jp0017')).to be_between(345_000, 346_000)
+  describe '#object_size' do
+    context 'when there is content' do
+      before do
+        allow(storage_repo).to receive(:storage_branch).and_return(BARE_TEST_DRUID)
+      end
+
+      it 'returns the size of a moab object' do
+        # values may differ from file system to file system (which is to be expected).
+        # if this test fails on your mac, make sure you don't have any extraneous .DS_Store files
+        # lingering in the fixture directories.
+        expect(storage_repo.object_size(BARE_TEST_DRUID)).to be_between(345_000, 346_000)
+      end
+    end
   end
 
   describe '#store_new_object_version' do
-    it 'calls storage_object and ingest_bag' do
-      bag_pathname = double('bag_pathname')
-      object_pathname = double('object_pathname')
-      storage_object = double(Moab::StorageObject)
-      expect(storage_repo).to receive(:storage_object).with(FULL_TEST_DRUID, true).and_return(storage_object)
+    let(:bag_pathname) { double('bag_pathname') }
+    let(:object_pathname) { double('object_pathname') }
+    let(:storage_object) { double(Moab::StorageObject) }
+
+    before do
       allow(storage_object).to receive(:object_pathname).and_return(object_pathname)
+    end
+
+    it 'calls storage_object and ingest_bag' do
+      expect(storage_repo).to receive(:storage_object).with(FULL_TEST_DRUID, true).and_return(storage_object)
       expect(storage_object).to receive(:ingest_bag).with(bag_pathname)
       storage_repo.store_new_object_version(FULL_TEST_DRUID, bag_pathname)
     end


### PR DESCRIPTION
## Why was this change made? 🤔

So this spec requires less cognitive load.

Part of #194

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to filesystem, or what is expected to be read from filesystem), run ***[integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** on stage as it tests preservation, and/or test in stage environment, in addition to specs.⚡


