### PR TITLE
rubocop: add new rule to appease our rubocop overlords

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -197,3 +197,6 @@ RSpec/Capybara/SpecificMatcher: # new in 2.12
   Enabled: true
 RSpec/Rails/HaveHttpStatus: # new in 2.12
   Enabled: true
+
+Style/MagicCommentFormat: # new in 1.35
+  Enabled: true


### PR DESCRIPTION
## Why was this change made? 🤔

because we haven't as a team decided to turn on 

```
  AllCops:
    NewCops: enable
```

as it could burden the FR unduly ?

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to filesystem, or what is expected to be read from filesystem), run ***[integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** on stage as it tests preservation, and/or test in stage environment, in addition to specs.⚡


