### PR TITLE
specs: get more informative output from equivalent-xml gem

### DIFF
--- a/spec/features/inventory/write_inventory_xml_spec.rb
+++ b/spec/features/inventory/write_inventory_xml_spec.rb
@@ -71,7 +71,6 @@ describe 'Feature: File Inventory Serialization' do
         </fileGroup>
       </fileInventory>
     XML
-    opts = { element_order: false, normalize_whitespace: true }
-    expect(EquivalentXml.equivalent?(xml_object1, Nokogiri::XML(expected_xml), opts)).to be true
+    expect(xml_object1).to be_equivalent_to(Nokogiri::XML(expected_xml))
   end
 end

--- a/spec/features/serializer/write_xml_spec.rb
+++ b/spec/features/serializer/write_xml_spec.rb
@@ -54,7 +54,6 @@ describe 'Feature: Manifest Serialization' do
         </entry>
       </signatureCatalog>
     XML
-    opts = { element_order: false, normalize_whitespace: true }
-    expect(EquivalentXml.equivalent?(xml_object1, Nokogiri::XML(expected_xml), opts)).to be true
+    expect(xml_object1).to be_equivalent_to(Nokogiri::XML(expected_xml))
   end
 end

--- a/spec/features/stanford/content_metadata_write_spec.rb
+++ b/spec/features/stanford/content_metadata_write_spec.rb
@@ -43,7 +43,6 @@ describe 'Write contentMetadata datastream' do
         </resource>
       </contentMetadata>
     XML
-    opts = { element_order: false, normalize_whitespace: true }
-    expect(EquivalentXml.equivalent?(xml_object1, Nokogiri::XML(expected_xml), opts)).to be true
+    expect(xml_object1).to be_equivalent_to(Nokogiri::XML(expected_xml))
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ SimpleCov.start do
   add_filter 'spec'
 end
 
-require 'equivalent-xml'
+require 'equivalent-xml/rspec_matchers'
 require 'moab/stanford'
 require 'spec_config'
 

--- a/spec/unit_tests/moab/file_group_difference_spec.rb
+++ b/spec/unit_tests/moab/file_group_difference_spec.rb
@@ -110,6 +110,7 @@ describe Moab::FileGroupDifference do
   describe '#compare_file_groups' do
     let(:basis_group) { v1_content }
     let(:other_group) { v3_content }
+
     # basis_group.group_id: "content"
     # basis_group.data_source: includes "data/jq937jp0017/v0001/content"
     # other_group.data_source: includes "data/jq937jp0017/v0003/content"
@@ -131,8 +132,6 @@ describe Moab::FileGroupDifference do
       expect(diff.difference_count).to eq 6
       expect(diff.deleted).to eq 6
     end
-
-    let(:eq_xml_opts) { { element_order: false, normalize_whitespace: true } }
 
     describe 'from parsed fileGroup xml' do
       let(:comp_file_groups_diff) do
@@ -192,7 +191,7 @@ describe Moab::FileGroupDifference do
             </file>
           </subset>
         XML
-        expect(EquivalentXml.equivalent?(copyadded_ng_xml, exp_ng_xml, eq_xml_opts)).to be true
+        expect(copyadded_ng_xml).to be_equivalent_to(exp_ng_xml)
       end
 
       it 'copydeleted subset' do
@@ -204,7 +203,7 @@ describe Moab::FileGroupDifference do
             </file>
           </subset>
         XML
-        expect(EquivalentXml.equivalent?(copydeleted_ng_xml, exp_ng_xml, eq_xml_opts)).to be true
+        expect(copydeleted_ng_xml).to be_equivalent_to(exp_ng_xml)
       end
 
       it 'renamed subset' do
@@ -216,7 +215,7 @@ describe Moab::FileGroupDifference do
             </file>
           </subset>
         XML
-        expect(EquivalentXml.equivalent?(renamed_ng_xml, exp_ng_xml, eq_xml_opts)).to be true
+        expect(renamed_ng_xml).to be_equivalent_to(exp_ng_xml)
       end
     end
   end

--- a/spec/unit_tests/moab/storage_object_spec.rb
+++ b/spec/unit_tests/moab/storage_object_spec.rb
@@ -11,7 +11,6 @@ describe Moab::StorageObject do
     storage_object_from_temp.storage_root = fixtures_dir.join('derivatives')
     storage_object_from_temp
   end
-  let(:eq_xml_opts) { { element_order: false, normalize_whitespace: true } }
 
   before do
     temp_object_dir.rmtree if temp_object_dir.exist?
@@ -381,15 +380,11 @@ describe Moab::StorageObject do
     end
 
     it 'returns the expected fileInventory.xml' do
-      expect(EquivalentXml.equivalent?(file_inventory_version_for_comparison_ng_xml,
-                                       Nokogiri::XML(exp_file_inventory_version_xml),
-                                       eq_xml_opts)).to be true
+      expect(file_inventory_version_for_comparison_ng_xml).to be_equivalent_to(exp_file_inventory_version_xml)
     end
 
     it 'creates the expected versionAdditions.xml' do
-      expect(EquivalentXml.equivalent?(file_inventory_additions_for_comparison_ng_xml,
-                                       Nokogiri::XML(exp_file_inventory_additions_xml),
-                                       eq_xml_opts)).to be true
+      expect(file_inventory_additions_for_comparison_ng_xml).to be_equivalent_to(exp_file_inventory_additions_xml)
     end
   end
 

--- a/spec/unit_tests/moab/storage_services_spec.rb
+++ b/spec/unit_tests/moab/storage_services_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 describe Moab::StorageServices do
-  let(:eq_xml_opts) { { element_order: false, normalize_whitespace: true } }
-
   it 'only instantiates StorageRepository once for the class, even if multiple threads try to access it' do
     # Object#object_id Returns an integer identifier for obj.  The same number will be returned
     # on all calls to object_id for a given object, and no two active objects will share an id.
@@ -226,6 +224,6 @@ describe Moab::StorageServices do
         </fileGroupDifference>
       </fileInventoryDifference>
     XML
-    expect(EquivalentXml.equivalent?(diff_ng_xml, Nokogiri::XML(exp_xml), eq_xml_opts)).to be true
+    expect(diff_ng_xml).to be_equivalent_to(Nokogiri::XML(exp_xml))
   end
 end

--- a/spec/unit_tests/stanford/content_inventory_spec.rb
+++ b/spec/unit_tests/stanford/content_inventory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 describe Stanford::ContentInventory do
-  let(:eq_xml_opts) { { element_order: false, normalize_whitespace: true } }
   let(:content_metadata_empty_subset) { File.read(fixtures_dir.join('bad_data/contentMetadata-empty-subsets.xml')) }
   let(:empty_inventory) do
     <<-XML
@@ -45,8 +44,7 @@ describe Stanford::ContentInventory do
           </fileGroup>
         </fileInventory>
       XML
-      exp_ng_xml = Nokogiri::XML(exp_xml)
-      expect(EquivalentXml.equivalent?(inventory_ng_xml, exp_ng_xml, eq_xml_opts)).to be true
+      expect(inventory_ng_xml).to be_equivalent_to(Nokogiri::XML(exp_xml))
     end
 
     it 'version_id = 1' do
@@ -92,8 +90,7 @@ describe Stanford::ContentInventory do
           </fileGroup>
         </fileInventory>
       XML
-      exp_ng_xml = Nokogiri::XML(exp_xml)
-      expect(EquivalentXml.equivalent?(inventory_ng_xml, exp_ng_xml, eq_xml_opts)).to be true
+      expect(inventory_ng_xml).to be_equivalent_to(Nokogiri::XML(exp_xml))
     end
   end
 
@@ -105,7 +102,7 @@ describe Stanford::ContentInventory do
       inventory_ng_xml.xpath('//@inventoryDatetime').remove
       exp_ng_xml = Nokogiri::XML(empty_inventory)
       exp_ng_xml.xpath('//@dataSource').each { |d| d.value = d.value.gsub(/subset/, subset) }
-      expect(EquivalentXml.equivalent?(inventory_ng_xml, exp_ng_xml, eq_xml_opts)).to be true
+      expect(inventory_ng_xml).to be_equivalent_to(exp_ng_xml)
     end
   end
 
@@ -206,8 +203,7 @@ describe Stanford::ContentInventory do
         </resource>
       </contentMetadata>
     XML
-    exp_ng_xml = Nokogiri::XML(exp_xml)
-    expect(EquivalentXml.equivalent?(generated_ng_xml, exp_ng_xml, eq_xml_opts)).to be true
+    expect(generated_ng_xml).to be_equivalent_to(Nokogiri::XML(exp_xml))
   end
 
   describe '#validate_content_metadata' do
@@ -283,8 +279,7 @@ describe Stanford::ContentInventory do
           </resource>
         </contentMetadata>
       XML
-      exp_ng_xml = Nokogiri::XML(exp_xml)
-      expect(EquivalentXml.equivalent?(remediated_ng_xml, exp_ng_xml, eq_xml_opts)).to be true
+      expect(remediated_ng_xml).to be_equivalent_to(Nokogiri::XML(exp_xml))
     end
 
     it 'bad size raises exception' do

--- a/spec/unit_tests/stanford/storage_services_spec.rb
+++ b/spec/unit_tests/stanford/storage_services_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 describe Stanford::StorageServices do
-  let(:eq_xml_opts) { { element_order: false, normalize_whitespace: true } }
   let(:content_metadata) { File.read(test_object_data_dir.join('v0002/metadata/contentMetadata.xml')) }
 
   it 'only instantiates StorageRepository once for the class, even if multiple threads try to access it' do
@@ -53,8 +52,7 @@ describe Stanford::StorageServices do
         </resource>
     </contentMetadata>
     XML
-    exp_ng_xml = Nokogiri::XML(exp_xml)
-    expect(EquivalentXml.equivalent?(remediated_cm_ng_xml, exp_ng_xml, eq_xml_opts)).to be true
+    expect(remediated_cm_ng_xml).to be_equivalent_to(Nokogiri::XML(exp_xml))
   end
 
   describe '.compare_cm_to_version_inventory' do
@@ -98,8 +96,7 @@ describe Stanford::StorageServices do
           </fileGroupDifference>
         </fileInventoryDifference>
       XML
-      exp_ng_xml = Nokogiri::XML(exp_xml)
-      expect(EquivalentXml.equivalent?(diff_ng_xml, exp_ng_xml, eq_xml_opts)).to be true
+      expect(diff_ng_xml).to be_equivalent_to(Nokogiri::XML(exp_xml))
     end
 
     it 'shelve subset' do
@@ -169,8 +166,7 @@ describe Stanford::StorageServices do
           </fileGroupDifference>
         </fileInventoryDifference>
       XML
-      exp_ng_xml = Nokogiri::XML(exp_xml)
-      expect(EquivalentXml.equivalent?(diff_ng_xml, exp_ng_xml, eq_xml_opts)).to be true
+      expect(diff_ng_xml).to be_equivalent_to(Nokogiri::XML(exp_xml))
     end
 
     it 'shelve subset without specified version' do
@@ -217,8 +213,7 @@ describe Stanford::StorageServices do
           </fileGroupDifference>
         </fileInventoryDifference>
       XML
-      exp_ng_xml = Nokogiri::XML(exp_xml)
-      expect(EquivalentXml.equivalent?(diff_ng_xml, exp_ng_xml, eq_xml_opts)).to be true
+      expect(diff_ng_xml).to be_equivalent_to(Nokogiri::XML(exp_xml))
     end
 
     it 'empty subset' do
@@ -246,7 +241,7 @@ describe Stanford::StorageServices do
         diff_ng_xml.xpath('//@reportDatetime').remove
         exp_ng_xml = Nokogiri::XML(inventory_diff)
         exp_ng_xml.xpath('//@other').each { |o| o.value = o.value.gsub(/xyz/, subset) }
-        expect(EquivalentXml.equivalent?(diff_ng_xml, exp_ng_xml, eq_xml_opts)).to be true
+        expect(diff_ng_xml).to be_equivalent_to(exp_ng_xml)
       end
     end
   end
@@ -267,8 +262,7 @@ describe Stanford::StorageServices do
           </fileGroup>
         </fileInventory>
       XML
-      exp_ng_xml = Nokogiri::XML(exp_xml)
-      expect(EquivalentXml.equivalent?(adds_ng_xml, exp_ng_xml, eq_xml_opts)).to be true
+      expect(adds_ng_xml).to be_equivalent_to(Nokogiri::XML(exp_xml))
     end
 
     it 'nil version' do
@@ -298,8 +292,7 @@ describe Stanford::StorageServices do
           </fileGroup>
         </fileInventory>
       XML
-      exp_ng_xml = Nokogiri::XML(exp_xml)
-      expect(EquivalentXml.equivalent?(adds_ng_xml, exp_ng_xml, eq_xml_opts)).to be true
+      expect(adds_ng_xml).to be_equivalent_to(Nokogiri::XML(exp_xml))
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

So rspec output shows the actual difference in the xml, rather than just "expected false, but it was true" 

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to filesystem, or what is expected to be read from filesystem), run ***[integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** on stage as it tests preservation, and/or test in stage environment, in addition to specs.⚡


