### PR TITLE
Keep pry-byebug as a dev dependency even in CI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,12 +11,15 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    byebug (11.1.3)
+    coderay (1.1.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
     druid-tools (3.0.0)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     json (2.6.3)
+    method_source (1.0.0)
     nokogiri (1.13.10-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.10-x86_64-linux)
@@ -26,6 +29,12 @@ GEM
     parallel (1.22.1)
     parser (3.2.0.0)
       ast (~> 2.4.1)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
     racc (1.6.2)
     rainbow (3.1.1)
     rake (13.0.6)
@@ -75,6 +84,7 @@ PLATFORMS
 DEPENDENCIES
   equivalent-xml
   moab-versioning!
+  pry-byebug
   rake
   rspec
   rubocop (~> 1.7)
@@ -82,4 +92,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.3.17
+   2.4.3

--- a/moab-versioning.gemspec
+++ b/moab-versioning.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'nokogiri-happymapper' # Object to XML Mapping Library, using Nokogiri
 
   s.add_development_dependency 'equivalent-xml'
-  s.add_development_dependency 'pry-byebug' unless ENV['CI']
+  s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop', '~> 1.7'


### PR DESCRIPTION
## Why was this change made? 🤔

Without this change, pulling `main` and running `bundle install` winds up causing changes to `Gemfile.lock`; namely, adding `pry-byebug` and its dependencies. That is jarring and it is not clear that the reason we added this check five years ago is something we still care about.

The original issue being worked around is TravisCI failing to add pry-byebug to the bundle because it did not support Ruby 2.2: https://github.com/sul-dlss/moab-versioning/pull/149

I suspect the reason this dep is left out of the lockfile is that `ENV['CI']` is `true` when generating weekly dep update PRs on Jenkins.

If this messes up Monday's dep update for moab-versioning, I'm the FR 🤷🏻‍♂️ 

## How was this change tested? 🤨

CI
