### PR TITLE
Update Rubocop, Rake, and RSpec usage

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -210,3 +210,42 @@ RSpec/NoExpectationExample: # new in 2.13
   Enabled: true
 RSpec/Capybara/SpecificFinders: # new in 2.13
   Enabled: true
+
+Lint/DuplicateMagicComment: # new in 1.37
+  Enabled: true
+Style/ArrayIntersect: # new in 1.40
+  Enabled: true
+Style/ConcatArrayLiterals: # new in 1.41
+  Enabled: true
+Style/MapToSet: # new in 1.42
+  Enabled: true
+Style/MinMaxComparison: # new in 1.42
+  Enabled: true
+Style/OperatorMethodCall: # new in 1.37
+  Enabled: true
+Style/RedundantConstantBase: # new in 1.40
+  Enabled: true
+Style/RedundantDoubleSplatHashBraces: # new in 1.41
+  Enabled: true
+Style/RedundantEach: # new in 1.38
+  Enabled: true
+Style/RedundantStringEscape: # new in 1.37
+  Enabled: true
+Style/YodaExpression: # new in 1.42
+  Enabled: true
+RSpec/DuplicatedMetadata: # new in 2.16
+  Enabled: true
+RSpec/PendingWithoutReason: # new in 2.16
+  Enabled: true
+RSpec/SortMetadata: # new in 2.14
+  Enabled: true
+RSpec/Capybara/NegationMatcher: # new in 2.14
+  Enabled: true
+RSpec/Capybara/SpecificActions: # new in 2.14
+  Enabled: true
+RSpec/FactoryBot/ConsistentParenthesesStyle: # new in 2.14
+  Enabled: true
+RSpec/FactoryBot/FactoryNameStyle: # new in 2.16
+  Enabled: true
+RSpec/Rails/InferredSpecType: # new in 2.14
+  Enabled: true

--- a/Rakefile
+++ b/Rakefile
@@ -1,33 +1,10 @@
 # frozen_string_literal: true
 
-require 'rake'
 require 'bundler/gem_tasks'
-
-begin
-  Bundler.setup(:default, :development)
-rescue Bundler::BundlerError => e
-  warn e.message
-  warn 'Run `bundle install` to install missing gems'
-  exit e.status_code
-end
-
 require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 
+RuboCop::RakeTask.new
 RSpec::Core::RakeTask.new(:spec)
 
-RSpec::Core::RakeTask.new(:features) do |spec|
-  spec.libs << 'lib' << 'spec'
-  spec.spec_files = FileList['spec/features/**/*_spec.rb']
-end
-
-require 'rubocop/rake_task'
-RuboCop::RakeTask.new
-
-task :clean do
-  puts 'Cleaning old coverage'
-  FileUtils.rm_f('coverage.data')
-  FileUtils.rm_r('coverage') if File.exist?('coverage')
-  FileUtils.rm_r('spec/fixtures/derivatives') if File.exist?('spec/fixtures/derivatives')
-end
-
-task default: %i[spec rubocop]
+task default: %i[rubocop spec]

--- a/spec/unit_tests/moab/storage_object_spec.rb
+++ b/spec/unit_tests/moab/storage_object_spec.rb
@@ -493,7 +493,7 @@ describe Moab::StorageObject do
       end
 
       it 'does not raise error' do
-        expect { storage_obj.reconstruct_version(1, bag_dir) }.not_to raise_error(Errno::EEXIST)
+        expect { storage_obj.reconstruct_version(1, bag_dir) }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

This commit contains some spring cleaning in order to help this gem keep pace with our current practices.

Includes:

* Add missing Rubocop rules
* Update Rakefile to remove outdated cruft and unnecessary setup / tasks
* Change `raise_error` usage in a spec in response to an RSpec warning


## How was this change tested? 🤨

CI + ran `rake` locally
