### PR TITLE
Add performance hacks to FileGroup and FileSignature classes

### DIFF
--- a/lib/moab/file_inventory_difference.rb
+++ b/lib/moab/file_inventory_difference.rb
@@ -87,11 +87,11 @@ module Moab
       @report_datetime = Time.now
       # get a union list of all group_ids present in either inventory
       group_ids = basis_inventory.group_ids | other_inventory.group_ids
-      group_ids.each do |group_id|
+      @group_differences = group_ids.map do |group_id|
         # get a pair of groups to compare, creating a empty group if not present in the inventory
         basis_group = basis_inventory.group(group_id) || FileGroup.new(group_id: group_id)
         other_group = other_inventory.group(group_id) || FileGroup.new(group_id: group_id)
-        @group_differences << FileGroupDifference.new.compare_file_groups(basis_group, other_group)
+        FileGroupDifference.new.compare_file_groups(basis_group, other_group)
       end
       self
     end

--- a/lib/stanford/content_inventory.rb
+++ b/lib/stanford/content_inventory.rb
@@ -124,7 +124,7 @@ module Stanford
       cm.to_xml
     end
 
-    # @param content_metadata [String,Nokogiri::XML::Document] The contentMetadata as a string or XML doc
+    # @param content_metadata [String, Nokogiri::XML::Document] The contentMetadata as a string or XML doc
     # @return [Boolean] True if contentMetadata has essential file attributes, else raise exception
     def validate_content_metadata(content_metadata)
       result = validate_content_metadata_details(content_metadata)


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #266

This commit changes the `FileGroup`, `FileInventoryDifference`, `FileSignature`, and `ContentInventory` classes in order to reduce performance bottlenecks when diffing moabs with voluminous content metadata. (See #266 for a breakdown of the profiling results and methodology.)

Generally, the changes were intended to avoid unnecessary mutations, to make more judicious use of iterators (more important when dealing with extremely large collections!), and to cut down on the sheer number of method invocations within operations being called millions of times for a large test object. Each of these methods were targeted based on [profiling analysis](https://github.com/sul-dlss/moab-versioning/issues/266#issuecomment-1406812866).

Specific changes include:

* `FileGroup#path_hash_subset`
  * Prefer filtering the `FileGroup#signature_hash` earlier in the process to avoid iterating over irrelevant entries
  * Prefer using the result of `Enumerable#map` over using `Enumerable#each` to incrementally mutate a hash
* `FileGroup#add_file_instance`
  * Sniff if `Hash#[]` returns `nil` instead of using `Hash#key?`,
* `FileInventoryDifference#compare`
  * Use the result of `Enumerable#map` instead of using `Enumerable#each` plus mutation via shovel operator
* `FileSignature`
  * Replace `n.nil? ? '' : n.to_s` with `n.to_s` in attr `on_save` procs, since `nil.to_s` returns `''`
* `FileSignature#checksums`
  * Prefer `Object#tap` and injecting checksums if present over calling `Hash#reject` and asking every value if it's either `nil?` or `empty?`
* `FileSignature#eql?`
  * Rescue `NoMethodError` instead of calling `respond_to?` twice for every call


## How was this change tested? 🤨

CI + stage
