### PR TITLE
Simplify delete_bag

### DIFF
--- a/lib/moab/bagger.rb
+++ b/lib/moab/bagger.rb
@@ -68,12 +68,7 @@ module Moab
     def delete_bag
       # make sure this looks like a bag before deleting
       if bag_pathname.join('bagit.txt').exist?
-        if bag_pathname.join('data').exist?
-          bag_pathname.rmtree
-        else
-          bag_pathname.children.each(&:delete)
-          bag_pathname.rmdir
-        end
+        bag_pathname.rmtree
       end
       nil
     end


### PR DESCRIPTION
## Why was this change made? 🤔

We're seeing some errors in DSA during sdr-ingest-transfer in accessionWF when the `/dor/export` bag directory is being cleaned up using `Moab::Bagger.reset_bag()`:

https://app.honeybadger.io/projects/54415/faults/121047515/01JZJQF1PZS3WK8W7KQGB4HADY

From the stack trace it appears that these are happening when the `data` directory doesn't exist? Since in both cases we are effectively doing a `rmtree` this change will simply do a `rmtree` instead of removing items in the directory and then the directory itself. The underlying filesystem is now WEKA NFS, and may not be behaving the way we expect it should.

It appears that DSA is the only code that is using `reset_bag()`?

https://github.com/search?q=org%3Asul-dlss+reset_bag&type=code&repo=&langOverride=&start_value=1

## How was this change tested? 🤨

unit tests
