### PR TITLE
Update testing advice

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,6 @@
 
 ## How was this change tested? 🤨
 
-⚡ ⚠ If this change has cross service impact (e.g. changes what is written to filesystem, or what is expected to be read from filesystem), run ***[integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** on stage as it tests preservation, and/or test in stage environment, in addition to specs.⚡
+⚡ ⚠ If this change has cross service impact (e.g. changes what is written to filesystem, or what is expected to be read from filesystem), run ***preassembly related integration tests*** on stage as it tests preservation, and/or test in stage environment, in addition to specs.⚡
 
 


### PR DESCRIPTION
## Why was this change made? 🤔

It looks like the `create_preassembly_image_spec` no longer exists, so the advice was adjusted to recommend running all the preassembly tests instead.

## How was this change tested? 🤨

n/a
