### PR TITLE
Omit nfs temp files from tag manifests.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -367,3 +367,20 @@ Style/ItBlockParameter: # new in 1.75
   Enabled: true
 RSpec/IncludeExamples: # new in 3.6
   Enabled: true
+
+Gemspec/AttributeAssignment: # new in 1.77
+  Enabled: true
+Layout/EmptyLinesAfterModuleInclusion: # new in 1.79
+  Enabled: true
+Lint/UselessDefaultValueArgument: # new in 1.76
+  Enabled: true
+Lint/UselessOr: # new in 1.76
+  Enabled: true
+Naming/PredicateMethod: # new in 1.76
+  Enabled: false
+Style/CollectionQuerying: # new in 1.77
+  Enabled: true
+Style/EmptyStringInsideInterpolation: # new in 1.76
+  Enabled: true
+Style/RedundantArrayFlatten: # new in 1.76
+  Enabled: true

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -63,7 +63,7 @@ Metrics/MethodLength:
 # ForbiddenPrefixes: is_, has_, have_
 # AllowedMethods: is_a?
 # MethodDefinitionMacros: define_method, define_singleton_method
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Exclude:
     - 'spec/**/*'
     - 'lib/moab/file_group.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ source 'https://rubygems.org'
 # Dependencies are defined in moab-versioning.gemspec
 
 gemspec
+
+gem 'debug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,17 +11,24 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    byebug (12.0.0)
-    coderay (1.1.3)
+    date (3.4.1)
+    debug (1.11.0)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     diff-lcs (1.6.2)
     docile (1.4.1)
     druid-tools (3.0.0)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
+    erb (5.0.2)
+    io-console (0.8.1)
+    irb (1.15.2)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.14.1)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
-    method_source (1.1.0)
     nokogiri (1.18.10-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.10-x86_64-darwin)
@@ -34,17 +41,22 @@ GEM
     parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
     prism (1.5.1)
-    pry (0.15.2)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-byebug (3.11.0)
-      byebug (~> 12.0)
-      pry (>= 0.13, < 0.16)
+    psych (5.2.6)
+      date
+      stringio
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.3.0)
+    rdoc (6.14.2)
+      erb
+      psych (>= 4.0.0)
     regexp_parser (2.11.3)
+    reline (0.6.2)
+      io-console (~> 0.5)
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -82,6 +94,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
+    stringio (3.1.7)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.1.0)
@@ -95,9 +108,9 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  debug
   equivalent-xml
   moab-versioning!
-  pry-byebug
   rake
   rspec
   rubocop (~> 1.7)

--- a/lib/moab/bagger.rb
+++ b/lib/moab/bagger.rb
@@ -227,12 +227,12 @@ module Moab
         manifest_file[type] = manifest_pathname[type].open('w')
       end
       bag_pathname.children.each do |file|
-        unless file.directory? || file.basename.to_s[0, 11] == 'tagmanifest'
-          signature = FileSignature.new.signature_from_file(file)
-          fixity = signature.fixity
-          DEFAULT_CHECKSUM_TYPES.each do |type|
-            manifest_file[type].puts("#{fixity[type]} #{file.basename}") if fixity[type]
-          end
+        next unless include_in_tagfile_manifests?(file)
+
+        signature = FileSignature.new.signature_from_file(file)
+        fixity = signature.fixity
+        DEFAULT_CHECKSUM_TYPES.each do |type|
+          manifest_file[type].puts("#{fixity[type]} #{file.basename}") if fixity[type]
         end
       end
     ensure
@@ -243,6 +243,13 @@ module Moab
               manifest_pathname[type].exist? && manifest_pathname[type].empty?
         end
       end
+    end
+
+    def include_in_tagfile_manifests?(file)
+      basename = file.basename.to_s
+      return false if file.directory? || basename.start_with?('tagmanifest') || basename.match?(/\A\.nfs\w+\z/)
+
+      true
     end
 
     # @return [Boolean] Create a tar file containing the bag

--- a/lib/moab/file_group_difference.rb
+++ b/lib/moab/file_group_difference.rb
@@ -364,7 +364,7 @@ module Moab
       end
       # Are any of the filenames the same in set of oldnames and set of newnames?
       intersection = oldnames & newnames
-      intersection.count > 0
+      intersection.any?
     end
 
     # @param [Array<Array<String>>] filepairs The set of oldname, newname pairs for all files being renamed

--- a/lib/moab/storage_object_validator.rb
+++ b/lib/moab/storage_object_validator.rb
@@ -75,7 +75,7 @@ module Moab
 
     def check_correctly_named_version_dirs
       errors = []
-      errors << result_hash(MISSING_DIR, 'no versions exist') unless version_directories.count > 0
+      errors << result_hash(MISSING_DIR, 'no versions exist') unless version_directories.any?
       version_directories.each do |version_dir|
         errors << result_hash(VERSION_DIR_BAD_FORMAT, version_dir) unless VERSION_DIR_PATTERN.match?(version_dir)
       end

--- a/moab-versioning.gemspec
+++ b/moab-versioning.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'nokogiri-happymapper' # Object to XML Mapping Library, using Nokogiri
 
   s.add_development_dependency 'equivalent-xml'
-  s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop', '~> 1.7'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ end
 require 'equivalent-xml/rspec_matchers'
 require 'moab/stanford'
 require 'spec_config'
+require 'debug'
 
 RSpec.configure do |config|
   config.before(:all) { fixture_setup }

--- a/spec/unit_tests/moab/bagger_spec.rb
+++ b/spec/unit_tests/moab/bagger_spec.rb
@@ -293,6 +293,8 @@ describe Moab::Bagger do
 
   it '#create_tagfile_manifests' do
     allow(submit_bag).to receive(:create_tagfile_manifests).and_call_original
+    # Add an NFS temp file to be ignored.
+    submit_bag.bag_pathname.join('.nfs000000000000000000001').open('w') {} # rubocop:disable Lint/EmptyBlock
     submit_bag.fill_bag(:depositor, submit_source_base)
     expect(submit_bag).to have_received(:create_tagfile_manifests)
     md5 = submit_bag.bag_pathname.join('tagmanifest-md5.txt')


### PR DESCRIPTION
closes #398

## Why was this change made? 🤔
NFS temp files were disrupting the order of the universe.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact (e.g. changes what is written to filesystem, or what is expected to be read from filesystem), run ***preassembly related integration tests*** on stage as it tests preservation, and/or test in stage environment, in addition to specs.⚡


